### PR TITLE
FlatJSONDocument incorrectly reports endOfDocument

### DIFF
--- a/modules/core/src/main/java/org/terrier/indexing/FlatJSONDocument.java
+++ b/modules/core/src/main/java/org/terrier/indexing/FlatJSONDocument.java
@@ -132,7 +132,7 @@ public class FlatJSONDocument implements Document {
     
     @Override
     public boolean endOfDocument() {
-    	return remainingTokens>0;
+    	return remainingTokens<=0;
     	
     }
 


### PR DESCRIPTION
Fix for incorrect reporting of end-of-document.