### PR TITLE
Memory DirectIndex Write Fix

### DIFF
--- a/modules/realtime/src/main/java/org/terrier/realtime/memory/MemoryDirectIndex.java
+++ b/modules/realtime/src/main/java/org/terrier/realtime/memory/MemoryDirectIndex.java
@@ -97,6 +97,7 @@ public class MemoryDirectIndex implements PostingIndex<MemoryPointer> {
 		}
 
 		public TIntArrayList getPl_doc() {
+			pl_termids.sort(); // We need to sort the term ids before iterating, or compression will break them on write
 			return pl_termids;
 		}
 

--- a/modules/tests/src/test/java/main/RealtimeTestSuite.java
+++ b/modules/tests/src/test/java/main/RealtimeTestSuite.java
@@ -1,4 +1,3 @@
-
 package main;
 
 /*
@@ -30,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.terrier.realtime.incremental.TestIncremental;
+import org.terrier.realtime.memory.TestMemoryDirect;
 import org.terrier.realtime.memory.TestMemoryIndex;
 import org.terrier.realtime.memory.TestMemoryIndexer;
 import org.terrier.realtime.memory.TestMemoryInvertedIndex;
@@ -51,6 +51,7 @@ import org.terrier.realtime.multi.TestMultiIndex;
         TestMemoryLexicon.class,
         TestMemoryMetaIndex.class,
         TestMultiIndex.class,
-        TestIncremental.class
+        TestIncremental.class,
+        TestMemoryDirect.class
 })
 public class RealtimeTestSuite{}

--- a/modules/tests/src/test/java/org/terrier/realtime/memory/TestMemoryDirect.java
+++ b/modules/tests/src/test/java/org/terrier/realtime/memory/TestMemoryDirect.java
@@ -1,0 +1,62 @@
+package org.terrier.realtime.memory;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.terrier.structures.postings.IterablePosting;
+
+public class TestMemoryDirect {
+
+	@Test
+	public void test_MemoryDirectPostingIteration() throws Exception {
+		
+		MemoryDirectIndex mdi = new MemoryDirectIndex(null);
+		
+		// Posting 1
+		int[] termids1 = { 0, 1, 2, 3, 4 };
+		int[] freqs1 = { 1, 2, 3, 4, 5 };
+		for (int i =0; i<termids1.length; i++) {
+			mdi.add(0, termids1[i], freqs1[i]);
+		}
+		
+		// Posting 2
+		int[] termids2 = { 5, 6, 1, 2, 3 };
+		int[] freqs2 = { 1, 2, 3, 4, 5 };
+		for (int i =0; i<termids2.length; i++) {
+			mdi.add(1, termids2[i], freqs2[i]);
+		}
+		
+		// Check that the ordering has not changed
+		IterablePosting postingIteratorFor1 = mdi.getPostings(0);
+		int previousId = -1;
+		while (!postingIteratorFor1.endOfPostings()) {
+			int nextTerm = postingIteratorFor1.next();
+			assertTrue(nextTerm>previousId);
+			checkIDHasTheCorrectFrequency(nextTerm, postingIteratorFor1.getFrequency(), termids1, freqs1);
+			previousId = nextTerm;
+		}
+		
+		// Check that terms were re-ordered
+		IterablePosting postingIteratorFor2 = mdi.getPostings(1);
+		previousId = -1;
+		while (!postingIteratorFor2.endOfPostings()) {
+			int nextTerm = postingIteratorFor2.next();
+			assertTrue(nextTerm>previousId);
+			checkIDHasTheCorrectFrequency(nextTerm, postingIteratorFor2.getFrequency(), termids2, freqs2);
+			previousId = nextTerm;
+		}
+		
+		mdi.close();
+		
+	}
+	
+	public void checkIDHasTheCorrectFrequency(int termid, int freq, int[] termids, int[] freqs) {
+		for (int i=0; i<termids.length; i++) {
+			if (termids[i]==termid) {
+				//System.out.println(termid+" "+freq+" "+freqs[i]);
+				assertEquals(freq, freqs[i]);
+			}
+		}
+	}
+	
+}


### PR DESCRIPTION
Fix for an issue with writting Memory Indices with attached DirectIndex structures. 

MemoryDirectIndex postings store ids in observed order, however, iteration when writting posting lists assumes assending order of termid (because of how on-disk compression works). This fix simply sorts the termids before iteration begins.

Issue originally identified through subsequent failure of the StructureMerger when merging multiple indices created via MemoryIndex write with direct indexing enabled (out-of-range termids caused merge failure, when in the second of any pair)