### PR TITLE
change charset to UTF-8 in search form part

### DIFF
--- a/src/webapps/simple/results.jsp
+++ b/src/webapps/simple/results.jsp
@@ -1,4 +1,4 @@
-<%@ page language="java" contentType="text/html; charset=ISO-8859-1"
+<%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"
     import="org.terrier.querying.*"
     import="org.terrier.structures.Index"

--- a/src/webapps/wt2g/results.jsp
+++ b/src/webapps/wt2g/results.jsp
@@ -1,4 +1,4 @@
-<%@ page language="java" contentType="text/html; charset=ISO-8859-1"
+<%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"
     import="org.terrier.querying.*"
     import="org.terrier.structures.Index"


### PR DESCRIPTION
In line 1 charset is set to ISO-8859-1 (even though page encoding is UTF-8 and in line 228 charset is UTF-8).
That caused a lot of problems while searching e.g. in Polish, causing search form from the main page working completely different than form at results page (and making it impossible to search with some letters and stating model). Setting UTF-8 here solved this problem.