### PR TITLE
expose low-level indexing API

### DIFF
--- a/modules/assemblies/pom.xml
+++ b/modules/assemblies/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/batch-indexers/pom.xml
+++ b/modules/batch-indexers/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/batch-indexers/src/main/java/org/terrier/applications/TRECIndexing.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/applications/TRECIndexing.java
@@ -141,7 +141,7 @@ public class TRECIndexing extends BatchIndexing {
 			}
 		}
 
-		loadIndexer(path, prefix).index(new Collection[] {collectionTREC});
+		loadIndexer(path, prefix).index(collectionTREC);
 		try{
 			collectionTREC.close();
 		} catch (Exception e) {

--- a/modules/batch-indexers/src/main/java/org/terrier/indexing/TRECCollection.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/indexing/TRECCollection.java
@@ -380,6 +380,12 @@ public class TRECCollection extends MultiDocumentFileCollection {
 					propertyIndex++;
 				}
 			} catch (IOException ioe) {
+
+				// if we are on the last file, then probably all files failed. make this exception fatal
+				if (FileNumber == FilesToProcess.size() -1 )
+				{
+					throw new RuntimeException("Error reading last file" + currentFilename + " : " + ioe,  ioe);
+				}
 				
 				logger.warn("Error Reading "
 					+ currentFilename + " : " + ioe

--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
@@ -396,6 +396,11 @@ public abstract class Indexer
 		fileNameNoExtension = path + ApplicationSetup.FILE_SEPARATOR + prefix;
 	}
 
+	/** Indexes document as provided by the specified iterator.
+	 * Used internally by createDirectIndex(Collection collection), but
+	 * can be used externally too.
+	 * @param iterDocs an iterator
+	  */	
 	public abstract long indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs);
 
 	/** Merge a series of numbered indices in the same path/prefix area. New merged index

--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terrier.indexing.Collection;
+import org.terrier.indexing.CollectionFactory;
 import org.terrier.indexing.Document;
 import org.terrier.structures.AbstractPostingOutputStream;
 import org.terrier.structures.BasicDocumentIndexEntry;
@@ -201,9 +202,14 @@ public abstract class Indexer
 	/**
 	 * An abstract method for creating the direct index, the document index
 	 * and the lexicon for the given collections.
-	 * @param collections Collection[] An array of collections to index
+	 * @param collection Collection An collection to index
 	 */
-	public abstract void createDirectIndex(Collection[] collections);
+	public abstract void createDirectIndex(Collection collection);
+
+	@Deprecated
+	public void createDirectIndex(Collection[] collections) {
+		createDirectIndex(CollectionFactory.compose(collections));
+	}
 	/**
 	 * An abstract method for creating the inverted index, given that the
 	 * the direct index, the document index and the lexicon have
@@ -343,6 +349,10 @@ public abstract class Indexer
 		if (BUILDER_BOUNDARY_DOCUMENTS.size() > 0)
 			logger.info("Watching for "+BUILDER_BOUNDARY_DOCUMENTS.size()+ " documents that force index builder boundaries.");
 	}
+
+	public void index(Collection[] collections) {
+		index(CollectionFactory.compose(collections));
+	}
 	
 	/**
 	 * Creates the data structures for a set of collections. 
@@ -352,21 +362,18 @@ public abstract class Indexer
 	 * the generated data structures.
 	 * @param collections The document collection objects to index.
 	 */
-	public void index(Collection[] collections) {
-		//the number of collections to index
-		final int numOfCollections = collections.length;
+	public void index(Collection collection) {
 		int counter = 0;
 		final String oldIndexPrefix = prefix;
 		
-		//while (collections[numOfCollections-1].hasNext()) {
-		while (! collections[numOfCollections-1].endOfCollection()) {	
+		while (! collection.endOfCollection()) {	
 			counter++;
 			
 			prefix = oldIndexPrefix + "_" + counter;
 			fileNameNoExtension = path + ApplicationSetup.FILE_SEPARATOR + prefix;
 			//ApplicationSetup.setupFilenames();
 			logger.info("creating the data structures " + prefix);
-			this.createDirectIndex(collections);
+			this.createDirectIndex(collection);
 			this.createInvertedIndex();
 		}
 		
@@ -385,10 +392,10 @@ public abstract class Indexer
 		}
 		//restore the prefix
 		prefix = oldIndexPrefix;
-		//ApplicationSetup.TERRIER_INDEX_PREFIX=oldIndexPrefix;
-		//ApplicationSetup.setupFilenames();
 		fileNameNoExtension = path + ApplicationSetup.FILE_SEPARATOR + prefix;
 	}
+
+	//public abstract void indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList> iterDocs);
 
 	/** Merge a series of numbered indices in the same path/prefix area. New merged index
 	  * will be stored at mpath/mprefix_highest+1.

--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
@@ -216,7 +216,7 @@ public abstract class Indexer
 	 * the direct index, the document index and the lexicon have
 	 * already been created.
 	 */
-	public abstract void createInvertedIndex();
+	//public abstract void createInvertedIndex();
 	
 	/**
 	 * An abstract method that returns the last component 
@@ -375,7 +375,6 @@ public abstract class Indexer
 			//ApplicationSetup.setupFilenames();
 			logger.info("creating the data structures " + prefix);
 			this.createDirectIndex(collection);
-			this.createInvertedIndex();
 		}
 		
 		//merge the data structures
@@ -401,7 +400,7 @@ public abstract class Indexer
 	 * can be used externally too.
 	 * @param iterDocs an iterator
 	  */	
-	public abstract long indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs);
+	public abstract void indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs);
 
 	/** Merge a series of numbered indices in the same path/prefix area. New merged index
 	  * will be stored at mpath/mprefix_highest+1.

--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
@@ -28,6 +28,7 @@ import gnu.trove.TObjectIntHashMap;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 
@@ -395,7 +396,7 @@ public abstract class Indexer
 		fileNameNoExtension = path + ApplicationSetup.FILE_SEPARATOR + prefix;
 	}
 
-	//public abstract void indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList> iterDocs);
+	public abstract long indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs);
 
 	/** Merge a series of numbered indices in the same path/prefix area. New merged index
 	  * will be stored at mpath/mprefix_highest+1.

--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/classical/BasicIndexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/classical/BasicIndexer.java
@@ -28,6 +28,7 @@ package org.terrier.structures.indexing.classical;
 import gnu.trove.TIntHashSet;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,6 +42,7 @@ import org.terrier.structures.FieldDocumentIndexEntry;
 import org.terrier.structures.FieldLexiconEntry;
 import org.terrier.structures.IndexOnDisk;
 import org.terrier.structures.Index;
+import org.terrier.structures.collections.MapEntry;
 import org.terrier.structures.indexing.CompressionFactory;
 import org.terrier.structures.indexing.DocumentIndexBuilder;
 import org.terrier.structures.indexing.DocumentPostingList;
@@ -199,6 +201,112 @@ public class BasicIndexer extends Indexer
 			return new FieldTermProcessor();
 		return new BasicTermProcessor();
 	}
+
+	public long indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs) {
+		long numberOfTokens = 0;
+		while(iterDocs.hasNext()) {
+			Map.Entry<Map<String,String>, DocumentPostingList> me = iterDocs.next();
+			if (me == null) {
+				continue;
+			}
+			DocumentPostingList _termsInDocument = me.getValue();
+			Map<String,String> props = me.getKey();
+
+			try
+			{
+				if (_termsInDocument.getDocumentLength() == 0)
+				{	/* this document is empty, add the minimum to the document index */
+					indexEmpty(props);
+				}
+				else
+				{	/* index this docuent */
+					numberOfTokens += numOfTokensInDocument;
+					indexDocument(props, _termsInDocument);
+				}
+			}
+			catch (Exception ioe)
+			{
+				logger.error("Failed to index "+props.get("docno"),ioe);
+				throw new RuntimeException(ioe);
+			}
+		}
+		return numberOfTokens;
+	}
+
+	protected class CollectionConsumer implements Iterator<Map.Entry<Map<String,String>, DocumentPostingList>>
+	{
+		boolean breakHere = false;
+		final Collection collection;
+		int numberOfDocuments = 0;
+		final boolean boundaryDocsEnabled = BUILDER_BOUNDARY_DOCUMENTS.size() > 0;
+
+		public CollectionConsumer(Collection c) {
+			this.collection = c;
+		}
+
+		public boolean hasNext() {
+			if (breakHere)
+				return false;
+			if (collection.endOfCollection())
+				return false;
+			return true;
+
+		}
+
+		public Map.Entry<Map<String,String>, DocumentPostingList> next()
+		{
+			boolean gotDoc = collection.nextDocument();
+			if (! gotDoc) {
+				breakHere = true;
+				return null;
+			}
+			numberOfDocuments++;
+			//get the next document from the collection
+			Document doc = collection.getDocument();		
+			if (doc == null) {
+				logger.warn("skipping null document"); 
+				return null;
+			}
+			/* setup for parsing */
+			createDocumentPostings();
+			String term; //term we're currently processing
+			int numOfTokensInDocument = 0;
+
+			//get each term in the document
+			while (!doc.endOfDocument()) {
+				if ((term = doc.getNextTerm())!=null && !term.equals("")) {
+					termFields = doc.getFields();
+					/* pass term into TermPipeline (stop, stem etc) */
+					pipeline_first.processTerm(term);
+					/* the term pipeline will eventually add the term to this object. */
+				}
+				if (MAX_TOKENS_IN_DOCUMENT > 0 && 
+						numOfTokensInDocument > MAX_TOKENS_IN_DOCUMENT)
+						break;
+			}
+			//if we didn't index all tokens from document,
+			//we need to get to the end of the document.
+			while (!doc.endOfDocument()) 
+				doc.getNextTerm();
+			
+			pipeline_first.reset();
+			/* we now have all terms in the DocumentTree, so we save the document tree */
+			
+			
+			if (MAX_DOCS_PER_BUILDER>0 && numberOfDocuments >= MAX_DOCS_PER_BUILDER)
+			{
+				breakHere = true;
+			}
+
+			if (boundaryDocsEnabled && BUILDER_BOUNDARY_DOCUMENTS.contains(doc.getProperty("docno")))
+			{
+				logger.warn("Document "+doc.getProperty("docno")+" is a builder boundary document. Boundary forced.");
+				breakHere = true;
+			}
+			return new MapEntry<Map<String,String>, DocumentPostingList>(doc.getAllProperties(), termsInDocument);
+		}
+	}
+
 		
 	/** 
 	 * Creates the direct index, the document index and the lexicon.
@@ -228,85 +336,22 @@ public class BasicIndexer extends Indexer
 			//	new DirectIndexBuilder(currentIndex, "direct");
 		docIndexBuilder = new DocumentIndexBuilder(currentIndex, "document", FIELDS);
 		metaBuilder = createMetaIndexBuilder();
+		
+		// this iterator consumes the Collection object
+		CollectionConsumer iterDocs = new CollectionConsumer(collection);
 		emptyDocIndexEntry = FIELDS ? new FieldDocumentIndexEntry(FieldScore.FIELDS_COUNT) : new BasicDocumentIndexEntry();
-				
-		//int LexiconCount = 0;
-		int numberOfDocuments = 0; int numberOfTokens = 0;
-		//final long startBunchOfDocuments = System.currentTimeMillis();
-		final boolean boundaryDocsEnabled = BUILDER_BOUNDARY_DOCUMENTS.size() > 0;
+						
 		boolean stopIndexing = false;
 		long startCollection = System.currentTimeMillis();
-		boolean notLastDoc = false;
-		//while(notLastDoc = collection.hasNext()) {
-		while ((notLastDoc = collection.nextDocument())) {
-			//get the next document from the collection
+		
+		// this performs the actual indexing
+		long numberOfTokens = indexDocuments(iterDocs);
+		int numberOfDocuments = iterDocs.numberOfDocuments; 
 
-			Document doc = collection.getDocument();
-			
-			if (doc == null) {
-				logger.warn("skipping null document"); continue;
-			}
-			numberOfDocuments++; 
-			/* setup for parsing */
-			createDocumentPostings();
-			String term; //term we're currently processing
-			numOfTokensInDocument = 0;
-
-			//get each term in the document
-			while (!doc.endOfDocument()) {
-				if ((term = doc.getNextTerm())!=null && !term.equals("")) {
-					termFields = doc.getFields();
-					/* pass term into TermPipeline (stop, stem etc) */
-					pipeline_first.processTerm(term);
-					/* the term pipeline will eventually add the term to this object. */
-				}
-				if (MAX_TOKENS_IN_DOCUMENT > 0 && 
-						numOfTokensInDocument > MAX_TOKENS_IN_DOCUMENT)
-						break;
-			}
-			//if we didn't index all tokens from document,
-			//we need to get to the end of the document.
-			while (!doc.endOfDocument()) 
-				doc.getNextTerm();
-			
-			pipeline_first.reset();
-			/* we now have all terms in the DocumentTree, so we save the document tree */
-			try
-			{
-				if (termsInDocument.getDocumentLength() == 0)
-				{	/* this document is empty, add the minimum to the document index */
-					indexEmpty(doc.getAllProperties());
-				}
-				else
-				{	/* index this docuent */
-					numberOfTokens += numOfTokensInDocument;
-					indexDocument(doc.getAllProperties(), termsInDocument);
-				}
-			}
-			catch (Exception ioe)
-			{
-				logger.error("Failed to index "+doc.getProperty("docno"),ioe);
-				throw new RuntimeException(ioe);
-			}
-			
-			if (MAX_DOCS_PER_BUILDER>0 && numberOfDocuments >= MAX_DOCS_PER_BUILDER)
-			{
-				stopIndexing = true;
-				break;
-			}
-
-			if (boundaryDocsEnabled && BUILDER_BOUNDARY_DOCUMENTS.contains(doc.getProperty("docno")))
-			{
-				logger.warn("Document "+doc.getProperty("docno")+" is a builder boundary document. Boundary forced.");
-				stopIndexing = true;
-				break;
-			}
-		}
-
-
-		if (! notLastDoc)
+		if (! collection.endOfCollection())
 		{
 			try{
+				System.err.println("Closing a collection");
 				collection.close();
 			} catch (IOException e) {
 				logger.warn("Couldnt close collection", e);

--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/classical/BlockIndexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/classical/BlockIndexer.java
@@ -30,6 +30,7 @@ import gnu.trove.THashSet;
 import gnu.trove.TIntHashSet;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -82,13 +83,13 @@ import org.terrier.utility.TermCodes;
  * </ul>
  * @author Craig Macdonald, Vassilis Plachouras, Rodrygo Santos
  */
-public class BlockIndexer extends Indexer {
+public class BlockIndexer extends BasicIndexer {
 	
 	/** This class implements an end of a TermPipeline that adds the
 	 *  term to the DocumentTree. This TermProcessor does NOT have field
 	 *  support.
 	 */	 
-	protected class BasicTermProcessor implements TermPipeline {
+	protected class BlockTermProcessor implements TermPipeline {
 		public void processTerm(String t) {
 			//	null means the term has been filtered out (eg stopwords)
 			if (t != null) {
@@ -111,7 +112,7 @@ public class BlockIndexer extends Indexer {
 	 * term to the DocumentTree. This TermProcessor does have field
 	 * support.
 	 */
-	protected class FieldTermProcessor implements TermPipeline {
+	protected class BlockFieldTermProcessor implements TermPipeline {
 		final TIntHashSet fields = new TIntHashSet(numFields);
 		final boolean ELSE_ENABLED = fieldNames.containsKey("ELSE");
 		final int ELSE_FIELD_ID = fieldNames.get("ELSE") -1;
@@ -251,21 +252,10 @@ public class BlockIndexer extends Indexer {
 		}
 	}
 
-	/** The number of tokens in the current document so far. */
-	protected int numOfTokensInDocument = 0;
 	/** The number of tokens in the current block of the current document. */
 	protected int numOfTokensInBlock = 0;
 	/** The block number of the current document. */
 	protected int blockId;
-	/** The fields that are set for the current term. */
-	protected Set<String> termFields = null;
-	/** The list of terms in this document, and for each, the block occurrences. */
-	protected DocumentPostingList termsInDocument = null;
-	/**
-	 * Mapping of terms 2 termids
-	 */
-	protected TermCodes termCodes = new TermCodes();
-	
 	
 	/** The maximum number of terms allowed in a block. See Property <tt>blocks.size</tt> */
 	protected int BLOCK_SIZE;
@@ -275,11 +265,6 @@ public class BlockIndexer extends Indexer {
 	 * See Property <tt>blocks.max</tt>. */
 	protected int MAX_BLOCKS;
 	
-	/** The compression configuration for the direct index */
-	protected CompressionConfiguration compressionDirectConfig;
-	
-	/** The compression configuration for the inverted index */
-	protected CompressionConfiguration compressionInvertedConfig;
 
 	/** Constructs an instance of this class, where the created data structures
 	  * are stored in the given path, with the given prefix on the filenames.
@@ -319,168 +304,9 @@ public class BlockIndexer extends Indexer {
 				: new DelimTermProcessor(delims, indexDelims, countDelims);
 		}
 		else if (FieldScore.USE_FIELD_INFORMATION) {
-			return new FieldTermProcessor();
+			return new BlockFieldTermProcessor();
 		}
-		return new BasicTermProcessor();
-	}
-	
-	
-
-	/**
-	 * For the given collection, it iterates through the documents and
-	 * creates the direct index, document index and lexicon, using 
-	 * information about blocks and possibly fields.
-	 * @param collections Collection the collection to index.
-	 * @see org.terrier.structures.indexing.Indexer#createDirectIndex(org.terrier.indexing.Collection[])
-	 */
-	//TODO if this class extends BasicIndexer, then perhaps this method could be inherited
-	public void createDirectIndex(Collection collection) {
-		logger.info("BlockIndexer creating direct index"+ 
-			(Boolean.parseBoolean(ApplicationSetup.getProperty("block.delimiters.enabled", "false"))
-			? " delimited-block indexing enabled" : ""));
-		final boolean FIELDS = FieldScore.FIELDS_COUNT > 0;
-		currentIndex = IndexOnDisk.createNewIndex(path, prefix);
-		lexiconBuilder = FIELDS
-				? new LexiconBuilder(currentIndex, "lexicon", 
-						new FieldLexiconMap(FieldScore.FIELDS_COUNT), 
-						FieldLexiconEntry.class.getName(), "java.lang.String", "\""+ FieldScore.FIELDS_COUNT + "\"", 
-						termCodes)
-				: new LexiconBuilder(currentIndex, "lexicon", new LexiconMap(), BasicLexiconEntry.class.getName(), termCodes);
-
-		try{
-			directIndexBuilder = compressionDirectConfig.getPostingOutputStream(
-					currentIndex.getPath() + ApplicationSetup.FILE_SEPARATOR + currentIndex.getPrefix() + "." + "direct" + compressionDirectConfig.getStructureFileExtension());
-		} catch (Exception ioe) {
-			logger.error("Cannot make DirectInvertedOutputStream:", ioe);
-		}
-		docIndexBuilder = new DocumentIndexBuilder(currentIndex, "document", FIELDS);
-		metaBuilder = createMetaIndexBuilder();
-		emptyDocIndexEntry = FIELDS ? new FieldDocumentIndexEntry(FieldScore.FIELDS_COUNT) : new BasicDocumentIndexEntry();
-		
-		int numberOfDocuments = 0;
-		final boolean boundaryDocsEnabled = BUILDER_BOUNDARY_DOCUMENTS.size() > 0;
-		boolean stopIndexing = false;
-		long startCollection = System.currentTimeMillis();
-		boolean notLastDoc = false;
-		//while(notLastDoc = collection.hasNext()) {
-		while ((notLastDoc = collection.nextDocument())) {
-			//get the next document from the collection
-			
-			//String docid = collection.getDocid();
-			//Document doc = collection.next();
-			Document doc = collection.getDocument();
-			
-			if (doc == null)
-				continue;
-			
-			numberOfDocuments++;
-			//setup for parsing
-			createDocumentPostings();
-			String term;
-			numOfTokensInDocument = 0;
-			numOfTokensInBlock = 0;
-			blockId = 0;
-			//get each term in the document
-			while (!doc.endOfDocument()) {
-				if ((term = doc.getNextTerm()) != null && 
-					!term.equals("")) {
-					termFields = doc.getFields();
-					//pass term into TermPipeline (stop, stem etc)
-					pipeline_first.processTerm(term);
-					//the term pipeline will eventually add the term to this
-					// object.
-				}
-				if (MAX_TOKENS_IN_DOCUMENT > 0 && 
-					numOfTokensInDocument > MAX_TOKENS_IN_DOCUMENT)
-					break;
-			}
-			//if we didn't index all tokens from document,
-			//we need to get to the end of the document.
-			while (!doc.endOfDocument()) 
-				doc.getNextTerm();
-			//we now have all terms in the DocumentTree
-
-			pipeline_first.reset();
-			//process DocumentTree (tree of terms)
-			try
-			{
-				if (termsInDocument.getDocumentLength() == 0) { 
-					//this document is empty, add the
-					// minimum to the document index
-					indexEmpty(doc.getAllProperties());
-				} else { /* index this docuent */
-					//numberOfTokens += numOfTokensInDocument;
-					indexDocument(doc.getAllProperties(), termsInDocument);
-				}
-			}
-			catch (Exception ioe)
-			{
-				logger.error("Failed to index "+doc.getProperty("docno"),ioe);
-				throw new RuntimeException(ioe);
-			}
-			if (MAX_DOCS_PER_BUILDER>0 && numberOfDocuments >= MAX_DOCS_PER_BUILDER)
-			{
-				stopIndexing = true;
-				break;
-			}
-
-			if (boundaryDocsEnabled && BUILDER_BOUNDARY_DOCUMENTS.contains(doc.getProperty("docno")))
-			{
-				stopIndexing = true;
-				break;
-			}
-		}
-		long endCollection = System.currentTimeMillis();
-		long secs = ((endCollection-startCollection)/1000);
-		logger.info("Collection took "+secs+"seconds to index "
-			+"("+numberOfDocuments+" documents)\n");
-		if (secs > 3600)
-				logger.info("Rate: "+((double)numberOfDocuments/((double)secs/3600.0d))+" docs/hour");
-		if (emptyDocCount > 0)
-			logger.warn("Indexed " + emptyDocCount + " empty documents");
-		if (! notLastDoc)
-		{
-			try{
-				collection.close();
-			} catch (IOException e) {
-				logger.warn("Couldnt close collection", e);
-			}
-		}
-
-		/* end of the collection has been reached */
-		finishedDirectIndexBuild();
-		compressionDirectConfig.writeIndexProperties(currentIndex, "document-inputstream");
-		if (FIELDS)
-		{
-			currentIndex.addIndexStructure("document-factory", FieldDocumentIndexEntry.Factory.class.getName(), "java.lang.String", "${index.direct.fields.count}");
-		}
-		else
-		{
-			currentIndex.addIndexStructure("document-factory", BasicDocumentIndexEntry.Factory.class.getName(), "", "");
-		}
-		currentIndex.setIndexProperty("termpipelines", ApplicationSetup.getProperty("termpipelines", "Stopwords,PorterStemmer"));
-		/* flush the index buffers */
-		directIndexBuilder.close();
-		docIndexBuilder.finishedCollections();
-		/* and then merge all the temporary lexicons */
-		lexiconBuilder.finishedDirectIndexBuild();
-		try {
-			metaBuilder.close();
-		} catch (IOException ioe) {
-			logger.error("Could not finish MetaIndexBuilder: ", ioe);
-		}
-		if (FIELDS)
-		{
-			currentIndex.addIndexStructure("lexicon-valuefactory", FieldLexiconEntry.Factory.class.getName(), "java.lang.String", "${index.direct.fields.count}");
-		}
-		/* reset the in-memory mapping of terms to term codes.*/
-		termCodes.reset();
-		System.gc();
-		try {
-			currentIndex.flush();
-		} catch (IOException ioe) {
-			logger.error("Could not flush index properties: ", ioe);
-		}
+		return new BlockTermProcessor();
 	}
 
 	/** 

--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/singlepass/BasicSinglePassIndexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/singlepass/BasicSinglePassIndexer.java
@@ -156,8 +156,8 @@ public class BasicSinglePassIndexer extends BasicIndexer{
 
 
 	@Override
-	public void createDirectIndex(Collection[] collections) {
-		createInvertedIndex(collections);
+	public void createDirectIndex(Collection collection) {
+		createInvertedIndex(collection);
 	}
 	@Override
 	public void createInvertedIndex(){}
@@ -170,9 +170,9 @@ public class BasicSinglePassIndexer extends BasicIndexer{
 	 * Loops through each document in each of the collections,
 	 * extracting terms and pushing these through the Term Pipeline
 	 * (eg stemming, stopping, lowercase).
-	 *  @param collections Collection[] the collections to be indexed.
+	 *  @param collection Collection the collection to be indexed.
 	 */
-	public void createInvertedIndex(Collection[] collections) {
+	public void createInvertedIndex(Collection collection) {
 		logger.info("Creating IF (no direct file)..");
 		final boolean FIELDS = (FieldScore.FIELDS_COUNT > 0);
 		long startCollection, endCollection;
@@ -189,124 +189,118 @@ public class BasicSinglePassIndexer extends BasicIndexer{
 		MAX_DOCS_PER_BUILDER = UnitUtils.parseInt(ApplicationSetup.getProperty("indexing.max.docs.per.builder", "0"));
 		maxMemory = UnitUtils.parseLong(ApplicationSetup.getProperty("indexing.singlepass.max.postings.memory", "0"));
 		final boolean boundaryDocsEnabled = BUILDER_BOUNDARY_DOCUMENTS.size() > 0;
-		final int collections_length = collections.length;
 		boolean stopIndexing = false;
 		memoryAfterFlush = runtime.freeMemory();
 		logger.debug("Starting free memory: "+memoryAfterFlush/1000000+"M");
-
-		for(int collectionNo = 0; ! stopIndexing && collectionNo < collections_length; collectionNo++)
+		startCollection = System.currentTimeMillis();
+		while(collection.nextDocument())
+		//while(collection.hasNext())
 		{
-			Collection collection = collections[collectionNo];
-			startCollection = System.currentTimeMillis();
-			while(collection.nextDocument())
-			//while(collection.hasNext())
-			{
-				/* get the next document from the collection */
-				//Document doc = collection./next();
-				Document doc = collection.getDocument();
-				if (doc == null)
-					continue;
-				//numberOfDocuments++;
-				/* setup for parsing */
-				createDocumentPostings();
+			/* get the next document from the collection */
+			//Document doc = collection./next();
+			Document doc = collection.getDocument();
+			if (doc == null)
+				continue;
+			//numberOfDocuments++;
+			/* setup for parsing */
+			createDocumentPostings();
 
-				String term; //term we're currently processing
-				numOfTokensInDocument = 0;
-				//get each term in the document
-				while (!doc.endOfDocument()) {
+			String term; //term we're currently processing
+			numOfTokensInDocument = 0;
+			//get each term in the document
+			while (!doc.endOfDocument()) {
 
-					if ((term = doc.getNextTerm())!=null && !term.equals("")) {
-						termFields = doc.getFields();
-						/* pass term into TermPipeline (stop, stem etc) */
-						pipeline_first.processTerm(term);
-						/* the term pipeline will eventually add the term to this object. */
-					}
-					if (MAX_TOKENS_IN_DOCUMENT > 0 &&
-							numOfTokensInDocument > MAX_TOKENS_IN_DOCUMENT)
-						break;
+				if ((term = doc.getNextTerm())!=null && !term.equals("")) {
+					termFields = doc.getFields();
+					/* pass term into TermPipeline (stop, stem etc) */
+					pipeline_first.processTerm(term);
+					/* the term pipeline will eventually add the term to this object. */
 				}
-				//if we didn't index all tokens from document,
-				//we need to get to the end of the document.
-				while (!doc.endOfDocument())
-					doc.getNextTerm();
-				
-				pipeline_first.reset();
-				/* we now have all terms in the DocumentTree, so we save the document tree */
-				try
-				{
-					if (termsInDocument.getDocumentLength() == 0)
-					{	/* this document is empty, add the minimum to the document index */
-						indexEmpty(doc.getAllProperties());
-						if (IndexEmptyDocuments)
-						{
-							currentId++;
-							numberOfDocuments++;
-						}
-					}
-					else
-					{	/* index this document */
-						numberOfTokens += numOfTokensInDocument;
-						indexDocument(doc.getAllProperties(), termsInDocument);
-					}
-				}
-				catch (Exception ioe)
-				{
-					logger.error("Failed to index "+doc.getProperty("docno"),ioe);
-					throw new RuntimeException(ioe);
-				}
-
-				if (MAX_DOCS_PER_BUILDER>0 && numberOfDocuments >= MAX_DOCS_PER_BUILDER)
-				{
-					stopIndexing = true;
+				if (MAX_TOKENS_IN_DOCUMENT > 0 &&
+						numOfTokensInDocument > MAX_TOKENS_IN_DOCUMENT)
 					break;
-				}
-
-				if (boundaryDocsEnabled && BUILDER_BOUNDARY_DOCUMENTS.contains(doc.getProperty("docno")))
-				{
-					logger.warn("Document "+doc.getProperty("docno")+" is a builder boundary document. Boundary forced.");
-					stopIndexing = true;
-					break;
-				}
-				termsInDocument.clear();
 			}
+			//if we didn't index all tokens from document,
+			//we need to get to the end of the document.
+			while (!doc.endOfDocument())
+				doc.getNextTerm();
 			
-			try{
-				forceFlush();
-				endCollection = System.currentTimeMillis();
-				long partialTime = (endCollection-startCollection)/1000;
-				logger.info("Collection #"+collectionNo+ " took "+partialTime+ " seconds to build the runs for "+numberOfDocuments+" documents\n");
-							
-				
-				
-				docIndexBuilder.finishedCollections();
-				if (FieldScore.FIELDS_COUNT > 0)
-				{
-					currentIndex.addIndexStructure("document-factory", FieldDocumentIndexEntry.Factory.class.getName(), "java.lang.String", "${index.inverted.fields.count}");
+			pipeline_first.reset();
+			/* we now have all terms in the DocumentTree, so we save the document tree */
+			try
+			{
+				if (termsInDocument.getDocumentLength() == 0)
+				{	/* this document is empty, add the minimum to the document index */
+					indexEmpty(doc.getAllProperties());
+					if (IndexEmptyDocuments)
+					{
+						currentId++;
+						numberOfDocuments++;
+					}
 				}
 				else
-				{
-					currentIndex.addIndexStructure("document-factory", SimpleDocumentIndexEntry.Factory.class.getName(), "", "");
+				{	/* index this document */
+					numberOfTokens += numOfTokensInDocument;
+					indexDocument(doc.getAllProperties(), termsInDocument);
 				}
-				currentIndex.setIndexProperty("termpipelines", ApplicationSetup.getProperty("termpipelines", "Stopwords,PorterStemmer"));
-				metaBuilder.close();
-				currentIndex.flush();
-				
-				logger.info("Merging "+fileNames.size()+" runs...");
-				startCollection = System.currentTimeMillis();
-				
-				performMultiWayMerge();
-				currentIndex.flush();
-				endCollection = System.currentTimeMillis();
-				logger.info("Collection #"+collectionNo+" took "+((endCollection-startCollection)/1000)+" seconds to merge\n ");
-				logger.info("Collection #"+collectionNo+" total time "+( (endCollection-startCollection)/1000+partialTime));
-				long secs = ((endCollection-startCollection)/1000);
-				if (secs > 3600)
-					 logger.info("Rate: "+((double)numberOfDocuments/((double)secs/3600.0d))+" docs/hour");
-				if (emptyDocCount > 0)
-					logger.warn("Indexed " + emptyDocCount + " empty documents");
-			} catch (Exception e) {
-				logger.error("Problem finishing index", e);
 			}
+			catch (Exception ioe)
+			{
+				logger.error("Failed to index "+doc.getProperty("docno"),ioe);
+				throw new RuntimeException(ioe);
+			}
+
+			if (MAX_DOCS_PER_BUILDER>0 && numberOfDocuments >= MAX_DOCS_PER_BUILDER)
+			{
+				stopIndexing = true;
+				break;
+			}
+
+			if (boundaryDocsEnabled && BUILDER_BOUNDARY_DOCUMENTS.contains(doc.getProperty("docno")))
+			{
+				logger.warn("Document "+doc.getProperty("docno")+" is a builder boundary document. Boundary forced.");
+				stopIndexing = true;
+				break;
+			}
+			termsInDocument.clear();
+		}
+		
+		try{
+			forceFlush();
+			endCollection = System.currentTimeMillis();
+			long partialTime = (endCollection-startCollection)/1000;
+			logger.info("Collection took "+partialTime+ " seconds to build the runs for "+numberOfDocuments+" documents\n");
+						
+			
+			
+			docIndexBuilder.finishedCollections();
+			if (FieldScore.FIELDS_COUNT > 0)
+			{
+				currentIndex.addIndexStructure("document-factory", FieldDocumentIndexEntry.Factory.class.getName(), "java.lang.String", "${index.inverted.fields.count}");
+			}
+			else
+			{
+				currentIndex.addIndexStructure("document-factory", SimpleDocumentIndexEntry.Factory.class.getName(), "", "");
+			}
+			currentIndex.setIndexProperty("termpipelines", ApplicationSetup.getProperty("termpipelines", "Stopwords,PorterStemmer"));
+			metaBuilder.close();
+			currentIndex.flush();
+			
+			logger.info("Merging "+fileNames.size()+" runs...");
+			startCollection = System.currentTimeMillis();
+			
+			performMultiWayMerge();
+			currentIndex.flush();
+			endCollection = System.currentTimeMillis();
+			logger.info("Collection took "+((endCollection-startCollection)/1000)+" seconds to merge\n ");
+			logger.info("Collection total time "+( (endCollection-startCollection)/1000+partialTime));
+			long secs = ((endCollection-startCollection)/1000);
+			if (secs > 3600)
+					logger.info("Rate: "+((double)numberOfDocuments/((double)secs/3600.0d))+" docs/hour");
+			if (emptyDocCount > 0)
+				logger.warn("Indexed " + emptyDocCount + " empty documents");
+		} catch (Exception e) {
+			logger.error("Problem finishing index", e);
 		}
 		finishedInvertedIndexBuild();
 	}

--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/singlepass/ExtensibleSinglePassIndexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/singlepass/ExtensibleSinglePassIndexer.java
@@ -100,7 +100,7 @@ public abstract class ExtensibleSinglePassIndexer extends BasicSinglePassIndexer
 	 *  @param collections Collection[] the collections to be indexed.
 	 */
 	@Override
-	public void createInvertedIndex(Collection[] collections) {
+	public void createInvertedIndex(Collection collection) {
 		logger.info("Creating IF (no direct file)..");
 		long startCollection, endCollection;
 		fileNames = new LinkedList<String[]>();	
@@ -116,125 +116,120 @@ public abstract class ExtensibleSinglePassIndexer extends BasicSinglePassIndexer
 		MAX_DOCS_PER_BUILDER = Integer.parseInt(ApplicationSetup.getProperty("indexing.max.docs.per.builder", "0"));
 		maxMemory = Long.parseLong(ApplicationSetup.getProperty("indexing.singlepass.max.postings.memory", "0"));
 		final boolean boundaryDocsEnabled = BUILDER_BOUNDARY_DOCUMENTS.size() > 0;
-		final int collections_length = collections.length;
 		boolean stopIndexing = false;
 		System.gc();
 		memoryAfterFlush = runtime.freeMemory();
 		logger.debug("Starting free memory: "+memoryAfterFlush/1000000+"M");
 
-		for(int collectionNo = 0; ! stopIndexing && collectionNo < collections_length; collectionNo++)
+		startCollection = System.currentTimeMillis();
+		
+		while(collection.nextDocument())
 		{
-			Collection collection = collections[collectionNo];
-			startCollection = System.currentTimeMillis();
-			
-			while(collection.nextDocument())
-			{
-				/* get the next document from the collection */
-				//Document doc = collection./next();
-				Document doc = collection.getDocument();
-				if (doc == null)
-					continue;
-				//numberOfDocuments++;
-				/* setup for parsing */
-				createDocumentPostings();
+			/* get the next document from the collection */
+			//Document doc = collection./next();
+			Document doc = collection.getDocument();
+			if (doc == null)
+				continue;
+			//numberOfDocuments++;
+			/* setup for parsing */
+			createDocumentPostings();
 
-				String term; //term we're currently processing
-				numOfTokensInDocument = 0;
-				//get each term in the document
-				while (!doc.endOfDocument()) {
+			String term; //term we're currently processing
+			numOfTokensInDocument = 0;
+			//get each term in the document
+			while (!doc.endOfDocument()) {
 
-					if ((term = doc.getNextTerm())!=null && !term.equals("")) {
-						termFields = doc.getFields();
-						
-						//perform pre-op
-						preProcess(doc, term); //JH MOD
-						
-						/* pass term into TermPipeline (stop, stem etc) */
-						pipeline_first.processTerm(term);
-						/* the term pipeline will eventually add the term to this object. */
-					}
-					if (MAX_TOKENS_IN_DOCUMENT > 0 &&
-							numOfTokensInDocument > MAX_TOKENS_IN_DOCUMENT)
-						break;
+				if ((term = doc.getNextTerm())!=null && !term.equals("")) {
+					termFields = doc.getFields();
+					
+					//perform pre-op
+					preProcess(doc, term); //JH MOD
+					
+					/* pass term into TermPipeline (stop, stem etc) */
+					pipeline_first.processTerm(term);
+					/* the term pipeline will eventually add the term to this object. */
 				}
-				//if we didn't index all tokens from document,
-				//we need to get to the end of the document.
-				while (!doc.endOfDocument())
-					doc.getNextTerm();
-				
-				pipeline_first.reset();
-				/* we now have all terms in the DocumentTree, so we save the document tree */
-				try
-				{
-					if (termsInDocument.getDocumentLength() == 0)
-					{	/* this document is empty, add the minimum to the document index */
-						indexEmpty(doc.getAllProperties());
-						if (IndexEmptyDocuments)
-						{
-							currentId++;
-							numberOfDocuments++;
-						}
-					}
-					else
-					{	/* index this document */
-						numberOfTokens += numOfTokensInDocument;
-						indexDocument(doc.getAllProperties(), termsInDocument);
-					}
-				}
-				catch (Exception ioe)
-				{
-					logger.error("Failed to index "+doc.getProperty("docno"),ioe);
-				}
-
-				if (MAX_DOCS_PER_BUILDER>0 && numberOfDocuments >= MAX_DOCS_PER_BUILDER)
-				{
-					stopIndexing = true;
+				if (MAX_TOKENS_IN_DOCUMENT > 0 &&
+						numOfTokensInDocument > MAX_TOKENS_IN_DOCUMENT)
 					break;
-				}
-
-				if (boundaryDocsEnabled && BUILDER_BOUNDARY_DOCUMENTS.contains(doc.getProperty("docno")))
-				{
-					logger.warn("Document "+doc.getProperty("docno")+" is a builder boundary document. Boundary forced.");
-					stopIndexing = true;
-					break;
-				}
-				termsInDocument.clear();
 			}
+			//if we didn't index all tokens from document,
+			//we need to get to the end of the document.
+			while (!doc.endOfDocument())
+				doc.getNextTerm();
 			
-			try{
-				forceFlush();
-				endCollection = System.currentTimeMillis();
-				long partialTime = (endCollection-startCollection)/1000;
-				logger.info("Collection #"+collectionNo+ " took "+partialTime+ " seconds to build the runs for "+numberOfDocuments+" documents\n");
-							
-				
-				
-				docIndexBuilder.finishedCollections();
-				if (FieldScore.FIELDS_COUNT > 0)
-				{
-					currentIndex.addIndexStructure("document-factory", FieldDocumentIndexEntry.Factory.class.getName(), "java.lang.String", "${index.inverted.fields.count}");
+			pipeline_first.reset();
+			/* we now have all terms in the DocumentTree, so we save the document tree */
+			try
+			{
+				if (termsInDocument.getDocumentLength() == 0)
+				{	/* this document is empty, add the minimum to the document index */
+					indexEmpty(doc.getAllProperties());
+					if (IndexEmptyDocuments)
+					{
+						currentId++;
+						numberOfDocuments++;
+					}
 				}
 				else
-				{
-					currentIndex.addIndexStructure("document-factory", SimpleDocumentIndexEntry.Factory.class.getName(), "", "");
+				{	/* index this document */
+					numberOfTokens += numOfTokensInDocument;
+					indexDocument(doc.getAllProperties(), termsInDocument);
 				}
-				metaBuilder.close();
-				currentIndex.flush();
-				
-				logger.info("Merging "+fileNames.size()+" runs...");
-				startCollection = System.currentTimeMillis();
-				
-				performMultiWayMerge();
-				currentIndex.flush();
-				endCollection = System.currentTimeMillis();
-				logger.info("Collection #"+collectionNo+" took "+((endCollection-startCollection)/1000)+" seconds to merge\n ");
-				logger.info("Collection #"+collectionNo+" total time "+( (endCollection-startCollection)/1000+partialTime));
-				long secs = ((endCollection-startCollection)/1000);
-				if (secs > 3600)
-	                 logger.info("Rate: "+((double)numberOfDocuments/((double)secs/3600.0d))+" docs/hour");
-			} catch (Exception e) {
-				logger.error("Problem finishing index", e);
 			}
+			catch (Exception ioe)
+			{
+				logger.error("Failed to index "+doc.getProperty("docno"),ioe);
+			}
+
+			if (MAX_DOCS_PER_BUILDER>0 && numberOfDocuments >= MAX_DOCS_PER_BUILDER)
+			{
+				stopIndexing = true;
+				break;
+			}
+
+			if (boundaryDocsEnabled && BUILDER_BOUNDARY_DOCUMENTS.contains(doc.getProperty("docno")))
+			{
+				logger.warn("Document "+doc.getProperty("docno")+" is a builder boundary document. Boundary forced.");
+				stopIndexing = true;
+				break;
+			}
+			termsInDocument.clear();
+		}
+		
+		try{
+			forceFlush();
+			endCollection = System.currentTimeMillis();
+			long partialTime = (endCollection-startCollection)/1000;
+			logger.info("Collection took "+partialTime+ " seconds to build the runs for "+numberOfDocuments+" documents\n");
+						
+			
+			
+			docIndexBuilder.finishedCollections();
+			if (FieldScore.FIELDS_COUNT > 0)
+			{
+				currentIndex.addIndexStructure("document-factory", FieldDocumentIndexEntry.Factory.class.getName(), "java.lang.String", "${index.inverted.fields.count}");
+			}
+			else
+			{
+				currentIndex.addIndexStructure("document-factory", SimpleDocumentIndexEntry.Factory.class.getName(), "", "");
+			}
+			metaBuilder.close();
+			currentIndex.flush();
+			
+			logger.info("Merging "+fileNames.size()+" runs...");
+			startCollection = System.currentTimeMillis();
+			
+			performMultiWayMerge();
+			currentIndex.flush();
+			endCollection = System.currentTimeMillis();
+			logger.info("Collection took "+((endCollection-startCollection)/1000)+" seconds to merge\n ");
+			logger.info("Collection total time "+( (endCollection-startCollection)/1000+partialTime));
+			long secs = ((endCollection-startCollection)/1000);
+			if (secs > 3600)
+					logger.info("Rate: "+((double)numberOfDocuments/((double)secs/3600.0d))+" docs/hour");
+		} catch (Exception e) {
+			logger.error("Problem finishing index", e);
 		}
 		finishedInvertedIndexBuild();
 	}	

--- a/modules/batch-retrieval/pom.xml
+++ b/modules/batch-retrieval/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/concurrent/pom.xml
+++ b/modules/concurrent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/index-api/pom.xml
+++ b/modules/index-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/learning/pom.xml
+++ b/modules/learning/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/logging/pom.xml
+++ b/modules/logging/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/realtime/pom.xml
+++ b/modules/realtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/rest-client/pom.xml
+++ b/modules/rest-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/rest-server/pom.xml
+++ b/modules/rest-server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/retrieval-api/pom.xml
+++ b/modules/retrieval-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/tests/pom.xml
+++ b/modules/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.6</version>
+		<version>5.7-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/tests/src/test/java/org/terrier/indexing/TestIndexers.java
+++ b/modules/tests/src/test/java/org/terrier/indexing/TestIndexers.java
@@ -164,7 +164,6 @@ public class TestIndexers extends ApplicationSetupBasedTest {
 		
 		Collection col = new CollectionDocumentList(sourceDocs);
 		indexer.createDirectIndex(new Collection[]{col});
-		indexer.createInvertedIndex();
 		
 		Index index = null;
 		

--- a/modules/tests/src/test/java/org/terrier/realtime/MemoryIndexer.java
+++ b/modules/tests/src/test/java/org/terrier/realtime/MemoryIndexer.java
@@ -131,19 +131,16 @@ public class MemoryIndexer extends Indexer {
 	/** FIXME */
 	private int numberOfDocuments;
 
-	public long indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs)
+	public void indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs)
 	{
-		long toks = 0;
 		while(iterDocs.hasNext()) {
 			var me = iterDocs.next();
-			toks += me.getValue().getDocumentLength();
 			try{
 				memIndex.indexDocument(me.getKey(), me.getValue());
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}
 		}
-		return toks;
 	}
 
 	
@@ -214,10 +211,6 @@ public class MemoryIndexer extends Indexer {
 					+ ((double) numberOfDocuments / ((double) secs / 3600.0d))
 					+ " docs/hour");
 
-	}
-
-	/** FIXME */
-	public void createInvertedIndex() {
 	}
 
 	/** FIXME */

--- a/modules/tests/src/test/java/org/terrier/realtime/MemoryIndexer.java
+++ b/modules/tests/src/test/java/org/terrier/realtime/MemoryIndexer.java
@@ -31,6 +31,8 @@ import gnu.trove.TIntHashSet;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.Map;
+import java.util.Iterator;
 
 import org.terrier.indexing.Collection;
 import org.terrier.indexing.Document;
@@ -128,6 +130,22 @@ public class MemoryIndexer extends Indexer {
 
 	/** FIXME */
 	private int numberOfDocuments;
+
+	public long indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs)
+	{
+		long toks = 0;
+		while(iterDocs.hasNext()) {
+			var me = iterDocs.next();
+			toks += me.getValue().getDocumentLength();
+			try{
+				memIndex.indexDocument(me.getKey(), me.getValue());
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return toks;
+	}
+
 	
 	/** FIXME */
 	public void createDirectIndex(Collection collection) {

--- a/modules/tests/src/test/java/org/terrier/realtime/TestUtils.java
+++ b/modules/tests/src/test/java/org/terrier/realtime/TestUtils.java
@@ -102,7 +102,6 @@ public class TestUtils {
 		MemoryIndexer indexer = new MemoryIndexer();
 		assertNotNull(indexer);
 		indexer.createDirectIndex(new Collection[] { collection });
-		indexer.createInvertedIndex();
 		MemoryIndex index = (MemoryIndex) indexer.getIndex();
 		assertNotNull(index);
 		return index;
@@ -120,7 +119,6 @@ public class TestUtils {
 		MemoryIndexer indexer = new MemoryIndexer(true);
 		assertNotNull(indexer);
 		indexer.createDirectIndex(new Collection[] { collection });
-		indexer.createInvertedIndex();
 		MemoryIndex index = (MemoryIndex) indexer.getIndex();
 		assertTrue("Failed to create a memory fields index",index instanceof MemoryFieldsIndex);
 		

--- a/modules/tests/src/test/java/org/terrier/realtime/incremental/TestIncremental.java
+++ b/modules/tests/src/test/java/org/terrier/realtime/incremental/TestIncremental.java
@@ -133,7 +133,6 @@ public class TestIncremental extends ApplicationSetupBasedTest {
 						+ String.valueOf(prefix));
 		assertNotNull(indexer);
 		indexer.createDirectIndex(new Collection[] { coll });
-		indexer.createInvertedIndex();
 		IndexOnDisk index = IndexOnDisk.createIndex(
 				ApplicationSetup.TERRIER_INDEX_PATH,
 				ApplicationSetup.TERRIER_INDEX_PREFIX + "-"

--- a/modules/tests/src/test/java/org/terrier/realtime/memory/TestMemoryIndex.java
+++ b/modules/tests/src/test/java/org/terrier/realtime/memory/TestMemoryIndex.java
@@ -404,7 +404,6 @@ public class TestMemoryIndex extends ApplicationSetupBasedTest {
 				.getNumberOfDocuments());
 		assertEquals(0, indexer.getIndex().getLexicon().numberOfEntries());
 		indexer.createDirectIndex(new Collection[] { collection });
-		indexer.createInvertedIndex();
 		assertEquals(2, indexer.getIndex().getDocumentIndex()
 				.getNumberOfDocuments());
 		assertEquals(4, indexer.getIndex().getLexicon().numberOfEntries());

--- a/modules/tests/src/test/java/org/terrier/realtime/memory/TestMemoryIndexer.java
+++ b/modules/tests/src/test/java/org/terrier/realtime/memory/TestMemoryIndexer.java
@@ -48,7 +48,6 @@ public class TestMemoryIndexer extends TestIndexers {
 	protected Index doIndexing(Indexer indexer, boolean fieldsExpected,	Document[] sourceDocs) {
 		Collection col = new CollectionDocumentList(sourceDocs);
 		indexer.createDirectIndex(new Collection[] { col });
-		indexer.createInvertedIndex();
 		return ((MemoryIndexer) indexer).getIndex();
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.terrier</groupId>
 	<artifactId>terrier-platform</artifactId>
-	<version>5.6</version>
+	<version>5.7-SNAPSHOT</version>
 	<name>Terrier Information Retrieval Platform</name>
 	<description>Terrier IR platform</description>
 	<url>http://terrier.org</url>


### PR DESCRIPTION
The aim of this PR is to expose a lower-level indexing API, which allows client code to directly provide the indexed representation of documents. This will primarily be exposed in PyTerrier.

The exposed API is `Indexer.indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs)`

The opportunity has been taken to refactor the Indexer code, removing more duplication and unnecessary complications (e.g. `index(Collection[])` has been migrated to `index(Collection)`, and a `compose()` method added to CollectionFactory.

This is a draft PR at this stage. The following TODOs apply:
 - some unit test wrt. Merging (max docs per builder) are failing
 - its not clear yet how using indexDocuments() results in a completed index. The API from a client code is incomplete in this respect. One quick hack would be to subclass each indexer, and copy the relevant completion code? e.g.
```java

class BasicClientIndexer extends BasicIndexer {
  public long indexDocuments(Iterator<Map.Entry<Map<String,String>, DocumentPostingList>> iterDocs)
  {
     //bla setup code from createDirectIndex(Collection)
    super.indexDocuments(iterDocs);
    // bla completion code from createDirectIndex(Collection)
  }
}
```

  Alternatively, more code should be moved into indexDocuments() from createDirectIndex(Collection)