### PR TITLE
Docvectors support for Terrier-Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.versionsBackup
 *.class
 overview.html
 package.html
+.vscode/settings.json

--- a/modules/assemblies/pom.xml
+++ b/modules/assemblies/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 
@@ -101,6 +101,13 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>terrier-concurrent</artifactId>
+			<version>${project.version}</version>
+			<!-- <scope>provided</scope> -->
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>terrier-docvectors</artifactId>
 			<version>${project.version}</version>
 			<!-- <scope>provided</scope> -->
 		</dependency>

--- a/modules/batch-indexers/pom.xml
+++ b/modules/batch-indexers/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/batch-retrieval/pom.xml
+++ b/modules/batch-retrieval/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/concurrent/pom.xml
+++ b/modules/concurrent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/docvectors/README.md
+++ b/modules/docvectors/README.md
@@ -1,0 +1,35 @@
+# terrier-docvectors
+
+This is an module contains an alternative to the Fat framework for calculating more query dependent features. This framework has an additional advantage in that it can use rewriters to make additional query formulations, e.g. using [QueryExpansion](http://terrier.org/docs/current/javadoc/org/terrier/querying/QueryExpansion.html) upon the candidate set of ranked documents.
+
+## Installation
+
+	git clone /path/to/git
+	cd terrier-docvectors
+	mvn install
+	
+## Usage
+
+Similar to fat's ([FatFeaturedScoringMatching](http://terrier.org/docs/v5.1/javadoc/org/terrier/matching/FatFeaturedScoringMatching.html) class, there is a requirement of a list of features (usually features.list). However, DVFeaturedScoringMatching also has an extra file, a list of rewriters. Rewriters are Process classes that alter the query, and expected to extend [MQTRewritingProcess](http://terrier.org/docs/current/javadoc/org/terrier/querying/MQTRewritingProcess.html) (this includes the classical [QueryExpansion](http://terrier.org/docs/current/javadoc/org/terrier/querying/QueryExpansion.html) class). For example:
+
+	qeBo1:QueryExpansion(DFRBagExpansionTerms,Bo1)
+	qeKL:QueryExpansion(DFRBagExpansionTerms,KL)
+	prox:DependenceModelPreProcess
+
+Each of these create different query formulations, and tag the resulting query terms with the String before the colon (qeBo1, qeKL, etc). This allows a feature.list to be generated that targets these tagged query terms directly. For instance, if we write the following to etc/rewriters.list:
+
+	SAMPLE
+	WMODEL$qeBo1:BM25
+	WMODEL$qeKL:BM25
+	WMODEL$prox:org.terrier.matching.models.dependence.pBiL
+	WMODEL$prox:org.terrier.matching.models.dependence.MRF
+
+This feature definition file adds 4 additional features targetting the terms identified by the two query expansion and the proximity rewriter.
+
+Retrieval can then occur as follows:
+
+	bin/terrier br -Dtrec.matching=DVFeaturedScoringMatching,org.terrier.matching.daat.Full -Ddv.featured.scoring.matching.rewriters=FILE -Ddv.featured.scoring.matching.rewriters.file=./etc/rewriters.list -Dfat.featured.scoring.matching.features=FILE -Dfat.featured.scoring.matching.features.file=./etc/features.list
+
+## Contributors
+
+Written by Craig Macdonald

--- a/modules/docvectors/README.md
+++ b/modules/docvectors/README.md
@@ -1,16 +1,22 @@
 # terrier-docvectors
 
-This is an module contains an alternative to the Fat framework for calculating more query dependent features. This framework has an additional advantage in that it can use rewriters to make additional query formulations, e.g. using [QueryExpansion](http://terrier.org/docs/current/javadoc/org/terrier/querying/QueryExpansion.html) upon the candidate set of ranked documents.
+This is an module contains an alternative to the Fat framework for calculating more query dependent features. 
 
-## Installation
+Similar to fat's ([FatFeaturedScoringMatching](http://terrier.org/docs/current/javadoc/org/terrier/matching/FatFeaturedScoringMatching.html) class, there is a requirement of a list of features (usually features.list). 
 
-	git clone /path/to/git
-	cd terrier-docvectors
-	mvn install
-	
-## Usage
+## Recommended Usage
 
-Similar to fat's ([FatFeaturedScoringMatching](http://terrier.org/docs/v5.1/javadoc/org/terrier/matching/FatFeaturedScoringMatching.html) class, there is a requirement of a list of features (usually features.list). However, DVFeaturedScoringMatching also has an extra file, a list of rewriters. Rewriters are Process classes that alter the query, and expected to extend [MQTRewritingProcess](http://terrier.org/docs/current/javadoc/org/terrier/querying/MQTRewritingProcess.html) (this includes the classical [QueryExpansion](http://terrier.org/docs/current/javadoc/org/terrier/querying/QueryExpansion.html) class). For example:
+This class is available through PyTerrier, using  pt.FeaturesBatchRetrieve, where method is set to `'dv'`:
+```python
+retr = pt.FeaturesBatchRetrieve("./tests/fixtures/index/", ["WMODEL:PL2", "WMODEL:Tf"], wmodel="DPH", method='dv')
+```
+
+## Advanced Usage
+
+This framework has an additional advantage in that it can use rewriters to make additional query formulations, e.g. using [QueryExpansion](http://terrier.org/docs/current/javadoc/org/terrier/querying/QueryExpansion.html) upon the candidate set of ranked documents.
+
+
+However, DVFeaturedScoringMatching also has an extra file, a list of rewriters. Rewriters are Process classes that alter the query, and expected to extend [MQTRewritingProcess](http://terrier.org/docs/current/javadoc/org/terrier/querying/MQTRewritingProcess.html) (this includes the classical [QueryExpansion](http://terrier.org/docs/current/javadoc/org/terrier/querying/QueryExpansion.html) class). For example:
 
 	qeBo1:QueryExpansion(DFRBagExpansionTerms,Bo1)
 	qeKL:QueryExpansion(DFRBagExpansionTerms,KL)

--- a/modules/docvectors/pom.xml
+++ b/modules/docvectors/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>terrier-platform</artifactId>
+		<groupId>org.terrier</groupId>
+		<version>5.10-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
+	</parent>
+
+	<artifactId>terrier-docvectors</artifactId>
+	<name>terrier-docvectors</name>
+	
+	<dependencies>
+		<dependency>
+			<groupId>org.terrier</groupId>
+			<artifactId>terrier-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.terrier</groupId>
+			<artifactId>terrier-learning</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.terrier</groupId>
+			<artifactId>terrier-tests</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>net.sf.trove4j</groupId>
+			<artifactId>trove4j</artifactId>
+			<version>2.0.2</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching.java
+++ b/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching.java
@@ -1,0 +1,211 @@
+package org.terrier.matching;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.terrier.learning.FeaturedQueryResultSet;
+import org.terrier.matching.matchops.Operator;
+import org.terrier.matching.models.WeightingModel;
+import org.terrier.querying.MQTRewritingProcess;
+import org.terrier.querying.Request;
+import org.terrier.structures.FilterIndex;
+import org.terrier.structures.Index;
+import org.terrier.structures.PostingIndex;
+import org.terrier.structures.postings.ArrayOfIdsIterablePosting;
+import org.terrier.structures.postings.BlockPosting;
+import org.terrier.structures.postings.IterablePosting;
+import org.terrier.utility.ApplicationSetup;
+
+public class DVFeaturedScoringMatching extends FeaturedScoringMatching {
+
+	MQTRewritingProcess[] processes = new MQTRewritingProcess[0];
+	String[] processTags = new String[0];
+	
+	public DVFeaturedScoringMatching(Index _index, Matching _parent,
+			String[] _featureNames, String[] _rewriterNames) throws Exception {
+		super(_index, _parent, _featureNames, ScoringMatching.class);
+		parseRewriters(_rewriterNames);
+	}
+	
+	public DVFeaturedScoringMatching(Index _index, Matching _parent,
+			String[] _featureNames) throws Exception {
+		super(_index, _parent, _featureNames, ScoringMatching.class);
+		parseRewriters(getModelNames("dv.featured.scoring.matching.rewriters", true));
+	}
+
+	public DVFeaturedScoringMatching(Index _index, Matching _parent)
+			throws Exception {
+		super(_index, _parent, ScoringMatching.class);
+		parseRewriters(getModelNames("dv.featured.scoring.matching.rewriters", true));
+	}
+	
+	protected void parseRewriters(String[] rewriterName) {
+		List<String> _tags = new ArrayList<>();
+		List<MQTRewritingProcess> _processes = new ArrayList<>();
+		for(String line : rewriterName)
+		{
+			String[] parts = line.split(":", 2);
+			String tag = parts[0];
+			String[] parts2 = parts[1].split("\\(");
+			String classname = parts2[0];
+			if (! classname.contains("."))
+				classname = "org.terrier.querying." + classname;
+			String[] params  = new String[0];
+			if (parts2.length > 1)
+				params = parts2[1].replaceAll("\\)$", "").split(",");
+			
+			
+			Class<? extends MQTRewritingProcess> clz;
+			MQTRewritingProcess rtr;
+			try{
+				clz= ApplicationSetup.getClass(classname).asSubclass(MQTRewritingProcess.class);
+				if (params.length > 0)
+					rtr = clz.getConstructor(new Class[]{String[].class}).newInstance(new Object[]{params});
+				else
+					rtr = clz.newInstance();
+			}catch (Exception e) {
+				throw new IllegalArgumentException("when configuring " + classname, e);
+			}
+			_tags.add(tag);
+			_processes.add(rtr);
+			
+		}
+		processTags = _tags.toArray(new String[0]);
+		processes = _processes.toArray(new MQTRewritingProcess[0]);
+	}
+
+	@Override
+	public ResultSet match(String queryNumber, MatchingQueryTerms queryTerms)
+			throws IOException {
+		
+		final ResultSet res = parent.match(queryNumber, queryTerms);
+		if (res == null)
+		{
+			logger.warn("I got NO ResultSet from parent " + parent.getInfo() );
+			return new FeaturedQueryResultSet(0);
+		}
+		return doMatch(queryNumber, queryTerms, res);
+	}
+
+	@Override
+	public ResultSet doMatch(String queryNumber,
+			MatchingQueryTerms queryTerms, ResultSet res, boolean keepInputScores) throws IOException 
+	{
+		final int numResults = res.getResultSize();
+		final FeaturedQueryResultSet rtr = new FeaturedQueryResultSet(res);
+		int featureCount = 0;
+		if (res.getResultSize() == 0)
+		{
+			rtr.scores = new double[0];
+			rtr.docids = new int[0];
+			rtr.occurrences = new short[0];
+			return rtr;
+		}
+		
+		int[] docids = res.getDocids().clone();
+		
+		
+		boolean fields = index.getCollectionStatistics().getNumberOfFields() > 0;
+		//this is a hack
+		//nb, we use direct as perhaps the inverted has blocks and the direct does not
+		boolean blocks = index.getDirectIndex().getPostings(index.getDocumentIndex().getDocumentEntry(0)) instanceof BlockPosting;
+		
+		logger.info(this.getClass().getSimpleName() + " analysing " + docids.length + " documents blocks="+blocks+" fields="+fields);
+		final PostingIndex<?> dvInv = Direct2InvIndex.process(index, docids.clone(), blocks, fields);
+		
+		Index dvIndex = new FilterIndex(this.index){
+			@Override public PostingIndex<?> getInvertedIndex() {return dvInv;}
+		};
+		
+		int pi = -1;
+		//this newMQT is the target of our rewriting operations
+		MatchingQueryTerms newMQT = queryTerms.clone();
+		Set<Operator> existingOps = newMQT.stream().map(me -> me.getKey()).collect(Collectors.toSet());
+		for (MQTRewritingProcess p : processes) 
+		{
+			pi++;
+			Request r = new Request();
+			r.setIndex(dvIndex);
+			r.setMatchingQueryTerms(queryTerms.clone());
+			r.setResultSet(res);
+			p.configureIndex(dvIndex);
+			boolean changed = p.expandQuery(r.getMatchingQueryTerms(), r);
+			if (changed)
+			{
+				MatchingQueryTerms mqtNew = r.getMatchingQueryTerms();
+				String tag = processTags[pi];
+				mqtNew.stream()
+					.filter(me -> ! existingOps.contains( me.getKey()))
+					.forEach(me -> { me.getValue().tags.add(tag); newMQT.add(me); });
+			}
+		}
+		queryTerms = newMQT;
+		
+		if (sampleFeature)
+		{
+			rtr.putFeatureScores("SAMPLE", res.getScores());
+			featureCount++;
+		}
+
+		//for each WMODEL feature
+		for(int fid=0;fid<wModels.length;fid++)
+		{
+			wModels[fid].index = dvIndex;
+			MatchingQueryTerms mqtLocal = queryTerms.clone();
+			final ResultSet thinChild = wModels[fid].doMatch(queryNumber, mqtLocal, res.getResultSet(0, res.getResultSize()), false);
+			rtr.putFeatureScores(wModelNames[fid], thinChild.getScores());
+			featureCount++;
+		}
+		
+		//for each QI features
+		if (qiFeatures.length > 0)
+		{
+			IterablePosting ip = new ArrayOfIdsIterablePosting(docids);
+			for(int fid=0;fid<qiFeatures.length;fid++)
+			{
+				WeightingModel wm = qiFeatures[fid];
+				double[] scores = new double[numResults];
+				int di=0;
+				while(ip.next() != IterablePosting.EOL)
+				{
+					assert ip.getId() == docids[di];
+					scores[di++] = wm.score(ip);
+				}
+				rtr.putFeatureScores(qiFeatureNames[fid], scores);
+				featureCount++;
+			}
+		}
+		
+		//for each DSM feature
+		if (dsms.length > 0)
+		{
+			final MatchingQueryTerms mqtLocal = queryTerms.clone();
+			featureCount += applyDSMs(dvIndex, queryNumber, mqtLocal, numResults, docids, res.getOccurrences().clone(), rtr);
+		}
+		
+		if (keepInputScores) {
+			System.arraycopy(res.getScores(), 0, rtr.getScores(), 0, res.getResultSize());
+		}
+		
+		//labels
+		final String[] labels = new String[rtr.getResultSize()];
+		Arrays.fill(labels, "-1");
+		rtr.setLabels(labels);
+		
+		//metadata
+		if (res.hasMetaItems("docno"))
+		{
+			rtr.addMetaItems("docno", res.getMetaItems("docno"));
+		}
+		if (res.hasMetaItems("label"))
+			rtr.setLabels(res.getMetaItems("label"));
+		logger.info("Finished decorating " + queryNumber + " with " + featureCount + " features");
+		return rtr;
+		
+	}
+
+}

--- a/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching.java
+++ b/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import gnu.trove.TIntDoubleHashMap;
+
 import org.terrier.learning.FeaturedQueryResultSet;
 import org.terrier.matching.matchops.Operator;
 import org.terrier.matching.models.WeightingModel;
@@ -106,7 +108,7 @@ public class DVFeaturedScoringMatching extends FeaturedScoringMatching {
 			return rtr;
 		}
 		
-		int[] docids = res.getDocids().clone();
+		final int[] docids = res.getDocids().clone();
 		
 		
 		boolean fields = index.getCollectionStatistics().getNumberOfFields() > 0;
@@ -157,7 +159,9 @@ public class DVFeaturedScoringMatching extends FeaturedScoringMatching {
 			wModels[fid].index = dvIndex;
 			MatchingQueryTerms mqtLocal = queryTerms.clone();
 			final ResultSet thinChild = wModels[fid].doMatch(queryNumber, mqtLocal, res.getResultSet(0, res.getResultSize()), false);
-			rtr.putFeatureScores(wModelNames[fid], thinChild.getScores());
+			// restore any sort back to the expected ordering
+			final double[] sortedScores = sortById(resultsToMap(thinChild), docids);
+			rtr.putFeatureScores(wModelNames[fid], sortedScores);
 			featureCount++;
 		}
 		
@@ -206,6 +210,27 @@ public class DVFeaturedScoringMatching extends FeaturedScoringMatching {
 		logger.info("Finished decorating " + queryNumber + " with " + featureCount + " features");
 		return rtr;
 		
+	}
+
+	static final TIntDoubleHashMap resultsToMap(final ResultSet rs) {
+		
+		final int l = rs.getResultSize();
+		final int[] docids = rs.getDocids();
+		final double[] scores = rs.getScores();
+		final TIntDoubleHashMap rtr = new TIntDoubleHashMap(l);
+		for(int i=0;i<l;i++)
+			rtr.put(docids[i], scores[i]);
+		return rtr;
+	}
+
+	static final double[] sortById(final TIntDoubleHashMap docid2score, final int[] docids) {
+		final int l = docid2score.size();
+		assert l == docids.length;
+		final double[] rtr = new double[l];
+		for(int i=0;i<l;i++) {
+			rtr[i] = docid2score.get(docids[i]);
+		} 
+		return rtr;
 	}
 
 }

--- a/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching.java
+++ b/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching.java
@@ -22,7 +22,8 @@ import org.terrier.structures.postings.BlockPosting;
 import org.terrier.structures.postings.IterablePosting;
 import org.terrier.utility.ApplicationSetup;
 
-/** Uses Direct2InvIndex to make a mock InvertedIndex (from a DirectIndex) for rescoring documents for computing additional features.
+/** Implements the DocVectors style of computing additional features. Uses Direct2InvIndex to make a mock InvertedIndex 
+ * (from a DirectIndex) for rescoring documents for computing additional features.
  * Behaves the same way as FatFeaturedScoringMatching. This class can also support retrieval for only some "tagged" query terms.
  */
 public class DVFeaturedScoringMatching extends FeaturedScoringMatching {

--- a/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching.java
+++ b/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching.java
@@ -22,6 +22,9 @@ import org.terrier.structures.postings.BlockPosting;
 import org.terrier.structures.postings.IterablePosting;
 import org.terrier.utility.ApplicationSetup;
 
+/** Uses Direct2InvIndex to make a mock InvertedIndex (from a DirectIndex) for rescoring documents for computing additional features.
+ * Behaves the same way as FatFeaturedScoringMatching. This class can also support retrieval for only some "tagged" query terms.
+ */
 public class DVFeaturedScoringMatching extends FeaturedScoringMatching {
 
 	MQTRewritingProcess[] processes = new MQTRewritingProcess[0];

--- a/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching2.java
+++ b/modules/docvectors/src/main/java/org/terrier/matching/DVFeaturedScoringMatching2.java
@@ -1,0 +1,43 @@
+package org.terrier.matching;
+import org.terrier.structures.Index;
+import java.io.IOException;
+import org.terrier.learning.FeaturedQueryResultSet;
+
+/** Implements the DocVectors style of computing additional features, however uses Direct2WritablePostings to 
+ * make a FatResultsSet (from a DirectIndex) for rescoring documents for computing additional features.
+ * Extends FatFeaturedScoringMatching. This class does NOT support features expressed using "tagged" query terms.
+ */
+public class DVFeaturedScoringMatching2 extends FatFeaturedScoringMatching {
+
+	public DVFeaturedScoringMatching2(Index _index, Matching _parent, String[] _featureNames) throws Exception
+	{
+		super(_index, _parent, _featureNames);
+	}
+	
+	public DVFeaturedScoringMatching2(Index _index, Matching _parent) throws Exception
+	{
+		super(_index, _parent);
+	}
+
+	@Override
+	public ResultSet match(String queryNumber, MatchingQueryTerms queryTerms)
+			throws IOException 
+	{
+		final ResultSet res = parent.match(queryNumber, queryTerms);
+		if (res == null)
+		{
+			logger.warn("I got NO ResultSet from parent " + parent.getInfo() );
+			return new FeaturedQueryResultSet(0);
+		}
+		return doMatch(queryNumber, queryTerms, res, true);
+	}
+
+	@Override
+	public ResultSet doMatch(String queryNumber,
+			MatchingQueryTerms queryTerms, ResultSet res, boolean keepInputScores) throws IOException 
+	{
+		final FatResultSet fatRs = Direct2WritablePostings.decorateFromDirect(res, this.index, queryTerms);
+		return super.doMatch(queryNumber, queryTerms, fatRs, keepInputScores);
+	}
+
+}

--- a/modules/docvectors/src/main/java/org/terrier/matching/Direct2InvIndex.java
+++ b/modules/docvectors/src/main/java/org/terrier/matching/Direct2InvIndex.java
@@ -56,7 +56,7 @@ public class Direct2InvIndex  {
 				TIntArrayList poscount = term2poscount.get(termid);
 				TIntArrayList allpos = term2allpos.get(termid);
 				
-				if (ids == null)
+				if (ids == null) //defaultdict impementation :-)
 				{
 					assert freqs == null;
 					term2docids.put(termid, ids = new TIntArrayList());

--- a/modules/docvectors/src/main/java/org/terrier/matching/Direct2InvIndex.java
+++ b/modules/docvectors/src/main/java/org/terrier/matching/Direct2InvIndex.java
@@ -1,0 +1,200 @@
+package org.terrier.matching;
+
+import gnu.trove.TIntArrayList;
+import gnu.trove.TIntObjectHashMap;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.terrier.structures.DocumentIndex;
+import org.terrier.structures.DocumentIndexEntry;
+import org.terrier.structures.FieldDocumentIndex;
+import org.terrier.structures.Index;
+import org.terrier.structures.LexiconEntry;
+import org.terrier.structures.Pointer;
+import org.terrier.structures.PostingIndex;
+import org.terrier.structures.postings.ArrayOfBasicIterablePosting;
+import org.terrier.structures.postings.ArrayOfBlockFieldIterablePosting;
+import org.terrier.structures.postings.ArrayOfBlockIterablePosting;
+import org.terrier.structures.postings.ArrayOfFieldIterablePosting;
+import org.terrier.structures.postings.ArrayOfIdsIterablePosting;
+import org.terrier.structures.postings.BlockPosting;
+import org.terrier.structures.postings.FieldPosting;
+import org.terrier.structures.postings.IterablePosting;
+
+/** This class makes an inverted index for a subset of documents based upon a set of documents */
+public class Direct2InvIndex  {
+	
+	/* NB: the docids array will be sorted */
+	public static PostingIndex<Pointer> process(Index index, int[] docids, final boolean blocks, final boolean fields) throws IOException
+	{
+		assert(index.hasIndexStructure("direct"));
+		
+		final DocumentIndex doi = index.getDocumentIndex();
+		final FieldDocumentIndex fdoi = fields ? (FieldDocumentIndex) index.getDocumentIndex() : null;
+		
+		PostingIndex<?> di = index.getDirectIndex();
+		Arrays.sort(docids);
+		TIntObjectHashMap<TIntArrayList> term2docids = new TIntObjectHashMap<>();
+		TIntObjectHashMap<TIntArrayList> term2freqs = new TIntObjectHashMap<>();
+		TIntObjectHashMap<ArrayList<int[]>> term2fieldfreqs = new TIntObjectHashMap<>();
+		
+		TIntObjectHashMap<TIntArrayList> term2poscount = new TIntObjectHashMap<>();
+		TIntObjectHashMap<TIntArrayList> term2allpos = new TIntObjectHashMap<>();
+		
+		for(int docid : docids)
+		{
+			DocumentIndexEntry doiE = doi.getDocumentEntry(docid);
+			IterablePosting docPostings = di.getPostings(doiE);
+			int termid;
+			while( (termid = docPostings.next()) != IterablePosting.END_OF_LIST)
+			{
+				TIntArrayList ids = term2docids.get(termid);
+				TIntArrayList freqs = term2freqs.get(termid);
+				ArrayList<int[]> field_freqs = term2fieldfreqs.get(termid);
+				TIntArrayList poscount = term2poscount.get(termid);
+				TIntArrayList allpos = term2allpos.get(termid);
+				
+				if (ids == null)
+				{
+					assert freqs == null;
+					term2docids.put(termid, ids = new TIntArrayList());
+					term2freqs.put(termid,  freqs = new TIntArrayList());
+					if (fields)
+						term2fieldfreqs.put(termid, field_freqs = new ArrayList<>());
+					if (blocks)
+					{
+						term2poscount.put(termid, poscount = new TIntArrayList());
+						term2allpos.put(termid, allpos = new TIntArrayList());
+					}
+				}
+				ids.add(docid);
+				freqs.add(docPostings.getFrequency());
+				if (fields)
+					field_freqs.add( ((FieldPosting)docPostings).getFieldFrequencies() );
+				if (blocks)
+				{
+					poscount.add( ((BlockPosting)docPostings).getPositions().length );
+					allpos.add( ((BlockPosting)docPostings).getPositions() );
+				}
+			}
+		}
+		DVInv rtr = new DVInv();
+		for(int termid : term2docids.keys())
+		{
+			int[] ids = term2docids.get(termid).toNativeArray();
+			int[] freqs = term2freqs.get(termid).toNativeArray();
+			
+			int[][] field_freqs = fields ? term2fieldfreqs.get(termid).toArray(new int[0][]) : null;
+			int[] pos_count = blocks ? term2poscount.get(termid).toNativeArray() : null;
+			int[] allpos = blocks ? term2allpos.get(termid).toNativeArray() : null;
+			
+			assert ids.length == freqs.length;
+			
+			if (blocks)
+				if (fields)
+					rtr.term2postings.put(termid, new ArrayOfBlockFieldIterablePosting(ids, freqs, null, field_freqs, null, pos_count, allpos)
+					{
+						@Override
+						public int getDocumentLength() {
+							try {
+								return doi.getDocumentLength(this.getId());
+							} catch (IOException e) {
+								e.printStackTrace();
+								return 0;
+							}
+						}
+						
+						@Override
+						public int[] getFieldLengths() {
+							try {
+								return fdoi.getFieldLengths(this.getId());
+							} catch (IOException e) {
+								e.printStackTrace();
+								return null;
+							}
+						}
+						
+					});
+				else 
+					rtr.term2postings.put(termid, new ArrayOfBlockIterablePosting(ids, freqs, pos_count, allpos)
+					{
+						@Override
+						public int getDocumentLength() {
+							try {
+								return doi.getDocumentLength(this.getId());
+							} catch (IOException e) {
+								e.printStackTrace();
+								return 0;
+							}
+						}
+						
+					});
+			else 
+				if (fields)
+					rtr.term2postings.put(termid, new ArrayOfFieldIterablePosting(ids, freqs, null, field_freqs, null)
+					{
+						@Override
+						public int getDocumentLength() {
+							try {
+								return doi.getDocumentLength(this.getId());
+							} catch (IOException e) {
+								e.printStackTrace();
+								return 0;
+							}
+						}
+
+						@Override
+						public int[] getFieldLengths() {
+							try {
+								return fdoi.getFieldLengths(this.getId());
+							} catch (IOException e) {
+								e.printStackTrace();
+								return null;
+							}
+						}
+						
+					});
+				else
+					rtr.term2postings.put(termid, new ArrayOfBasicIterablePosting(ids, freqs)
+					{
+						@Override
+						public int getDocumentLength() {
+							try {
+								return doi.getDocumentLength(this.getId());
+							} catch (IOException e) {
+								e.printStackTrace();
+								return 0;
+							}
+						}
+						
+						
+						
+					});
+		}
+		return rtr;
+	}
+	
+	public static class DVInv implements PostingIndex<Pointer>
+	{
+
+		TIntObjectHashMap<ArrayOfIdsIterablePosting> term2postings = new TIntObjectHashMap<>();
+		
+		@Override
+		public void close() throws IOException {
+			term2postings.clear();
+		}
+
+		@Override
+		public IterablePosting getPostings(Pointer lEntry) throws IOException {
+			int termid = ((LexiconEntry) lEntry).getTermId();
+			ArrayOfIdsIterablePosting ip = term2postings.get(termid);
+			ip = ip.clone();
+			ip.reset();
+			return ip;
+		}
+		
+	}
+	
+}

--- a/modules/docvectors/src/main/java/org/terrier/matching/Direct2WritablePostings.java
+++ b/modules/docvectors/src/main/java/org/terrier/matching/Direct2WritablePostings.java
@@ -1,0 +1,82 @@
+package org.terrier.matching;
+
+import gnu.trove.TIntIntHashMap;
+
+import java.util.Set;
+import org.terrier.structures.Index;
+import org.terrier.structures.PostingIndex;
+import org.terrier.structures.Lexicon;
+import org.terrier.structures.DocumentIndex;
+import org.terrier.structures.LexiconEntry;
+import org.terrier.structures.EntryStatistics;
+import org.terrier.structures.FieldEntryStatistics;
+
+import org.terrier.learning.*;
+import org.terrier.structures.postings.IterablePosting;
+import org.terrier.structures.postings.WritablePosting;
+import org.terrier.structures.postings.FieldPosting;
+import java.io.IOException;
+
+/** This class makes a FatResultSet from a DirectIndex. This can be used to facilitate further scoring */
+public class Direct2WritablePostings {
+
+    static FatResultSet decorateFromDirect(ResultSet rs, Index index, MatchingQueryTerms mqt) throws IOException {
+        Set<String>[] ts = new Set[mqt.length()];
+        for (int i=0;i<ts.length;i++)
+        {
+            ts[i] = mqt.get(mqt.getTerms()[i]).getValue().getTags();
+        }
+        return decorateFromDirect(rs, index, mqt.getTerms(), mqt.getTermWeights(), ts);
+    }
+
+    static FatResultSet decorateFromDirect(ResultSet rs, Index index, String[] qs, double[] ks, Set<String>[] ts)  throws IOException {
+        assert index.hasIndexStructure("direct");
+
+        final DocumentIndex doi = index.getDocumentIndex();
+        final PostingIndex<?> direct = index.getDirectIndex();
+        final Lexicon<String> lex = index.getLexicon();
+        final int[] docids = rs.getDocids();
+        final int l = docids.length;
+        final int t = ks.length;
+        final int fieldCount = index.getCollectionStatistics().getNumberOfFields();
+        
+        final EntryStatistics[] entryStats = new EntryStatistics[t];
+        final WritablePosting[][] postings = new WritablePosting[l][t];        
+        final boolean[] fields = new boolean[t];
+        final TIntIntHashMap termIds = new TIntIntHashMap(t);
+        for (int i=0; i<t; i++) {
+            LexiconEntry le = lex.getLexiconEntry(qs[i]);
+			entryStats[i] = le.getWritableEntryStatistics();
+            fields[i] = entryStats[i] instanceof FieldEntryStatistics;
+            termIds.put(le.getTermId(), i+1);
+		}
+
+        for (int i=0;i<l;i++) {
+            IterablePosting ip = direct.getPostings(doi.getDocumentEntry(docids[i]));
+            while (ip.next() != IterablePosting.EOL) {
+                int termOffset = termIds.get(ip.getId());
+                if (termOffset == 0)
+                    continue;
+                termOffset--;
+                WritablePosting wp = postings[i][termOffset] = ip.asWritablePosting();
+                wp.setDocumentLength(ip.getDocumentLength());
+                if (fields[termOffset])
+                {
+                    final int[] fieldLengths =  ((FieldPosting)ip).getFieldLengths();
+                    final int[] newFieldLengths = new int[fieldCount];
+                    System.arraycopy(fieldLengths, 0, newFieldLengths, 0, fieldCount);
+                    // assert fieldLengths.length == super.cs.getNumberOfFields() 
+                    //     : " posting "+p +" for docid " + ip.getId() + " has wrong number of fields for length";
+                    ((FieldPosting)wp).setFieldLengths(newFieldLengths);
+                }
+            }
+        }
+        FatQueryResultSet fat = new FatQueryResultSet(l, index.getCollectionStatistics(), qs, entryStats, ks, ts);
+        fat.setPostings(postings);
+        fat.setDocids(docids);
+        fat.setScores(rs.getScores());
+        return fat;
+    }
+    
+
+}

--- a/modules/docvectors/src/main/java/org/terrier/structures/FilterIndex.java
+++ b/modules/docvectors/src/main/java/org/terrier/structures/FilterIndex.java
@@ -35,6 +35,11 @@ public abstract class FilterIndex extends Index {
 	}
 
 	@Override
+	public boolean hasIndexStructure(String structureName) {
+        return parent.hasIndexStructure(structureName);
+    }
+
+	@Override
 	public Object getIndexStructure(String structureName) {
 		return parent.getIndexStructure(structureName);
 	}

--- a/modules/docvectors/src/main/java/org/terrier/structures/FilterIndex.java
+++ b/modules/docvectors/src/main/java/org/terrier/structures/FilterIndex.java
@@ -1,0 +1,67 @@
+package org.terrier.structures;
+
+import java.io.IOException;
+import org.terrier.querying.IndexRef;
+
+public abstract class FilterIndex extends Index {
+
+	Index parent;
+	public FilterIndex(Index _parent) {
+		this.parent = _parent;
+	}
+
+	@Override public IndexRef getIndexRef() { 
+		return makeDirectIndexRef(this); 
+	}
+	
+	@Override
+	public void close() throws IOException {
+		parent.close();
+	}
+
+	@Override
+	public CollectionStatistics getCollectionStatistics() {
+		return parent.getCollectionStatistics();
+	}
+
+	@Override
+	public PostingIndex<?> getDirectIndex() {
+		return parent.getDirectIndex();
+	}
+
+	@Override
+	public DocumentIndex getDocumentIndex() {
+		return parent.getDocumentIndex();
+	}
+
+	@Override
+	public Object getIndexStructure(String structureName) {
+		return parent.getIndexStructure(structureName);
+	}
+
+	@Override
+	public Object getIndexStructureInputStream(String structureName) {
+		return parent.getIndexStructureInputStream(structureName);
+	}
+
+	@Override
+	public PostingIndex<?> getInvertedIndex() {
+		return parent.getInvertedIndex();
+	}
+
+	@Override
+	public Lexicon<String> getLexicon() {
+		return parent.getLexicon();
+	}
+
+	@Override
+	public MetaIndex getMetaIndex() {
+		return parent.getMetaIndex();
+	}
+
+	@Override
+	public String toString() {
+		return parent.toString();
+	}
+
+}

--- a/modules/docvectors/src/test/java/org/terrier/matching/DVIndexTest.java
+++ b/modules/docvectors/src/test/java/org/terrier/matching/DVIndexTest.java
@@ -1,0 +1,124 @@
+package org.terrier.matching;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.terrier.indexing.IndexTestUtils;
+import org.terrier.matching.matchops.PhraseOp;
+import org.terrier.matching.matchops.UnorderedWindowOp;
+import org.terrier.matching.models.Tf;
+import org.terrier.querying.parser.Query.QTPBuilder;
+import org.terrier.structures.EntryStatistics;
+import org.terrier.structures.FilterIndex;
+import org.terrier.structures.Index;
+import org.terrier.structures.Lexicon;
+import org.terrier.structures.LexiconEntry;
+import org.terrier.structures.NgramEntryStatistics;
+import org.terrier.structures.Pointer;
+import org.terrier.structures.PostingIndex;
+import org.terrier.structures.postings.IterablePosting;
+import org.terrier.tests.ApplicationSetupBasedTest;
+
+public class DVIndexTest extends ApplicationSetupBasedTest
+{
+	@Test public void testTwo() throws Exception
+	{
+		Index index = IndexTestUtils.makeIndex(new String[]{"a", "b"}, new String[]{"aa bb aa cc", "bb"});
+		PostingIndex<Pointer> newInv = Direct2InvIndex.process(index, new int[]{0,1}, false, false);
+		Lexicon<String> lex = index.getLexicon();
+		LexiconEntry le;
+		IterablePosting ip;
+		le = lex.getLexiconEntry("aa");
+		ip = newInv.getPostings(le);
+		assertEquals(0, ip.next());
+		assertEquals(2, ip.getFrequency());
+		assertEquals(4, ip.getDocumentLength());
+		assertEquals(IterablePosting.EOL, ip.next());
+		
+		ip = newInv.getPostings(le);
+		assertEquals(0, ip.next());
+		assertEquals(2, ip.getFrequency());
+		assertEquals(4, ip.getDocumentLength());
+		assertEquals(IterablePosting.EOL, ip.next());
+		
+		le = lex.getLexiconEntry("bb");
+		ip = newInv.getPostings(le);
+		assertEquals(0, ip.next());
+		assertEquals(1, ip.getFrequency());
+		assertEquals(4, ip.getDocumentLength());
+		assertEquals(1, ip.next());
+		assertEquals(1, ip.getFrequency());
+		assertEquals(1, ip.getDocumentLength());
+		assertEquals(IterablePosting.EOL, ip.next());
+		
+	}
+	
+	@Test public void testTwoMatchOpsBlocks() throws Exception
+	{
+		Index index = IndexTestUtils.makeIndexBlocks(new String[]{"a", "b"}, new String[]{"aa bb aa cc", "bb"});
+		PostingIndex<Pointer> newInv = Direct2InvIndex.process(index, new int[]{0,1}, true, false);
+		
+		Index dvIndex = new FilterIndex(index){
+			@Override public PostingIndex<?> getInvertedIndex() {return newInv;}
+		};
+		
+		MatchingQueryTerms mqt = new MatchingQueryTerms();
+		mqt.setQueryId("w-matchops");
+		mqt.setTermProperty("aa", 1.0d);
+		mqt.setTermProperty("bb", 1.0d);		
+		mqt.add(QTPBuilder
+				.of(new PhraseOp(new String[]{"aa", "bb"}))
+				.setWeight(0.1).setTag("sdm")
+				.setWeightingModels(Arrays.asList(new Tf()))
+				.build());
+		mqt.add(QTPBuilder
+				.of(new UnorderedWindowOp(new String[]{"aa", "bb"}, 2))
+				.setWeight(0.1).setTag("sdm")
+				.setWeightingModels(Arrays.asList(new Tf()))
+				.build());
+		mqt.setDefaultTermWeightingModel(new Tf());
+		PostingListManager plm = new PostingListManager(dvIndex, index.getCollectionStatistics(), mqt);
+		plm.prepare(false);
+		
+		EntryStatistics es;
+		IterablePosting ip;
+		
+		
+		ip = plm.getPosting(0);
+		assertEquals(0, ip.next());
+		assertEquals(2, ip.getFrequency());
+		assertEquals(4, ip.getDocumentLength());
+		assertEquals(IterablePosting.EOL, ip.next());
+		
+		ip = plm.getPosting(1);
+		assertEquals("bb", plm.getTerm(1));
+		assertEquals(0, ip.next());
+		assertEquals(1, ip.getFrequency());
+		assertEquals(4, ip.getDocumentLength());
+		assertEquals(1, ip.next());
+		assertEquals(1, ip.getFrequency());
+		assertEquals(1, ip.getDocumentLength());
+		assertEquals(IterablePosting.EOL, ip.next());
+		
+		ip = plm.getPosting(2);
+		es = plm.getStatistics(2);
+		assertTrue(es instanceof NgramEntryStatistics);
+		assertEquals(0, ip.next());
+		assertEquals(1, ip.getFrequency());
+		assertEquals(4, ip.getDocumentLength());
+		assertEquals(IterablePosting.EOL, ip.next());
+		
+		ip = plm.getPosting(3);
+		es = plm.getStatistics(2);
+		assertTrue(es instanceof NgramEntryStatistics);
+		assertEquals(0, ip.next());
+		assertTrue(ip.getFrequency() >= 1); //TODO check with Nic
+		assertEquals(4, ip.getDocumentLength());
+		assertEquals(IterablePosting.EOL, ip.next());
+		
+		plm.close();
+		
+	}
+}

--- a/modules/docvectors/src/test/java/org/terrier/matching/TestDVFeaturedScoringMatching.java
+++ b/modules/docvectors/src/test/java/org/terrier/matching/TestDVFeaturedScoringMatching.java
@@ -1,0 +1,303 @@
+/*
+ * Terrier - Terabyte Retriever 
+ * Webpage: http://terrier.org 
+ * Contact: terrier{a.}dcs.gla.ac.uk
+ * University of Glasgow - School of Computing Science
+ * http://www.gla.ac.uk/
+ * 
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+ * the License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * The Original Code is TestFatFeaturedScoringMatching.java.
+ *
+ * The Original Code is Copyright (C) 2004-2018 the University of Glasgow.
+ * All Rights Reserved.
+ *
+ * Contributor(s):
+ *   Craig Macdonald <craig.macdonald@glasgow.ac.uk>
+ */
+
+package org.terrier.matching;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import gnu.trove.TIntIntHashMap;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.terrier.indexing.IndexTestUtils;
+import org.terrier.learning.FeaturedResultSet;
+import org.terrier.matching.daat.Full;
+import org.terrier.matching.matchops.PhraseOp;
+import org.terrier.matching.matchops.UnorderedWindowOp;
+import org.terrier.matching.models.BM25;
+import org.terrier.matching.models.TF_IDF;
+import org.terrier.matching.models.Tf;
+import org.terrier.querying.DependenceModelPreProcess;
+import org.terrier.querying.MQTRewritingProcess;
+import org.terrier.querying.QueryExpansion;
+import org.terrier.querying.parser.Query.QTPBuilder;
+import org.terrier.structures.Index;
+import org.terrier.structures.IndexOnDisk;
+import org.terrier.tests.ApplicationSetupBasedTest;
+import org.terrier.utility.ApplicationSetup;
+
+public class TestDVFeaturedScoringMatching extends ApplicationSetupBasedTest {
+	
+	@Test 
+	public void rewritingExpansionsParsing() throws Exception
+	{
+		String f = super.writeTemporaryFile("temp.rewriters", 
+			new String[]{
+				"qeBo1:QueryExpansion(DFRBagExpansionTerms,Bo1)",
+				"qeKL:QueryExpansion(DFRBagExpansionTerms,KL)"
+		});
+		ApplicationSetup.setProperty("dv.featured.scoring.matching.rewriters", "FILE");
+		ApplicationSetup.setProperty("dv.featured.scoring.matching.rewriters.file", f);
+		Index index = IndexOnDisk.createIndex("/Users/craigm/wt2g_index/index/", "data");
+		DVFeaturedScoringMatching ffsm = new DVFeaturedScoringMatching(index, null, 
+				new String[]{"SAMPLE", "WMODEL$qeBo1:BM25", "WMODEL$qeKL:BM25"}
+		);
+		assertEquals(2, ffsm.processes.length);
+		
+	}
+	
+	// @Test public void rewritingExpansions() throws Exception
+	// {
+	// 	ApplicationSetup.setProperty("termpipelines", "");
+	// 	ApplicationSetup.setProperty("ignore.low.idf.terms", "false");
+	// 	ApplicationSetup.setProperty("proximity.dependency.type","SD");
+	// 	Index index = IndexOnDisk.createIndex("/Users/craigm/wt2g_index/index/", "data");
+		
+				
+	// 	MatchingQueryTerms mqt = new MatchingQueryTerms();
+	// 	mqt.setQueryId("test");
+	// 	mqt.setTermProperty("behavioral", 1.0d);
+	// 	mqt.setTermProperty("genetics", 1.0d);
+	// 	mqt.setDefaultTermWeightingModel(new BM25());
+	// 	mqt.stream().forEach(me -> me.getValue().getTags().add("firstmatchscore"));
+	// 	Matching m = new Full(index);
+		
+	// 	ResultSet frInput = m.match("test", mqt);
+	// 	assertTrue(frInput.getResultSize() > 1);
+	// 	assertTrue(frInput.getScores()[0] >= 0);
+	// 	final int[] origDocids = frInput.getDocids().clone();
+			
+	// 	DVFeaturedScoringMatching ffsm = new DVFeaturedScoringMatching(index, null, 
+	// 			new String[]{"SAMPLE", "WMODEL$qe:BM25"}
+	// 	);
+	// 	ffsm.processes = new MQTRewritingProcess[]{
+	// 		new QueryExpansion(),
+	// 		new DependenceModelPreProcess()
+	// 	};
+	// 	ffsm.processTags = new String[]{"qe", "sdm"};
+		
+	// 	ResultSet r2 = ffsm.doMatch("test", mqt, frInput);
+		
+	// 	assertTrue(r2.getResultSize() > 1);
+	// 	assertTrue(r2.getScores()[0] >= 0);
+	// 	assertEquals(frInput.getScores()[0], r2.getScores()[0], 0.0d);
+		
+	// 	FeaturedResultSet featRes = (FeaturedResultSet)r2;
+	// 	final double[] sample = featRes.getFeatureScores("SAMPLE");
+	// 	assertTrue(sample.length > 1);
+		
+	// 	final double[] qe = featRes.getFeatureScores("WMODEL$qe:BM25");
+	// 	assertTrue(qe.length > 1);
+
+	// 	assertArrayEquals(origDocids, featRes.getDocids());
+	// }
+	
+	@Test 
+	public void singleDocumentSingleTerm() throws Exception
+	{
+		ApplicationSetup.setProperty("termpipelines", "");
+		ApplicationSetup.setProperty("ignore.low.idf.terms", "false");
+		ApplicationSetup.setProperty("proximity.dependency.type","SD");
+		Index index = IndexTestUtils.makeIndex(
+				new String[]{"doc1"}, 
+				new String[]{"term"});
+		MatchingQueryTerms mqt = new MatchingQueryTerms();
+		mqt.setTermProperty("term", 1.0d);
+		mqt.setDefaultTermWeightingModel(new TF_IDF());
+		Matching m = new Full(index);
+		
+		ResultSet frInput = m.match("singleDocumentSingleTerm-Q1", mqt);
+		assertEquals(1, frInput.getResultSize());
+		assertEquals(0, frInput.getDocids()[0]);
+		assertTrue(frInput.getScores()[0] > 0);
+			
+		DVFeaturedScoringMatching ffsm = new DVFeaturedScoringMatching(index, null, 
+				new String[]{"WMODEL:Tf", "WMODEL:Dl", "DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier"}
+		);
+		ResultSet r2 = ffsm.doMatch("singleDocumentSingleTerm-Q2", mqt, frInput);
+		
+		assertEquals(1, r2.getResultSize());
+		assertEquals(0, r2.getDocids()[0]);
+		assertEquals(frInput.getScores()[0], r2.getScores()[0], 0.0d);
+		
+		FeaturedResultSet featRes = (FeaturedResultSet)r2;
+		final double[] tfs = featRes.getFeatureScores("WMODEL:Tf");
+		assertEquals(1, tfs.length);
+		assertEquals(1, tfs[0], 0.0d);
+		
+		final double[] dls = featRes.getFeatureScores("WMODEL:Dl");
+		assertEquals(1, dls.length);
+		assertEquals(1, dls[0], 0.0d);
+		
+		final double[] prox = featRes.getFeatureScores("DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier");
+		assertNotNull(prox);
+		//single term query can have no proximity, however, feature MUST be defined
+		assertEquals(0.0d, prox[0], 0.0d);
+	}
+	
+	@Test public void multiDocMultipleTermsWithTags() throws Exception
+	{
+		ApplicationSetup.setProperty("termpipelines", "");
+		ApplicationSetup.setProperty("ignore.low.idf.terms", "false");
+		ApplicationSetup.setProperty("proximity.dependency.type","SD");
+		Index index = IndexTestUtils.makeIndexBlocks(
+				new String[]{"doc1", "dox2"}, 
+				new String[]{"the lazy lazy dog jumped over the quick fox", "lazy fox fox fox"});
+		MatchingQueryTerms mqt = new MatchingQueryTerms();
+		mqt.setQueryId("test2");
+		mqt.setTermProperty("lazy", 1.0d);
+		mqt.get("lazy").getValue().setTag(BaseMatching.BASE_MATCHING_TAG);
+		
+		mqt.setTermProperty("fox", 1.0d);
+		mqt.get("fox").getValue().setTag("second");
+		mqt.get("fox").getValue().tags.remove(BaseMatching.BASE_MATCHING_TAG);
+		mqt.setDefaultTermWeightingModel(new Tf());
+		//mqt.matchOnTags.add("first");
+		Matching m = new Full(index);
+		ResultSet frInput = m.match("query1", mqt);
+		
+		assertEquals(2, frInput.getResultSize());
+		assertEquals(0, frInput.getDocids()[0]);
+		assertEquals(2, frInput.getScores()[0], 0d);//tf for lazy in docid0
+		assertEquals(1, frInput.getDocids()[1]);
+		assertEquals(1, frInput.getScores()[1], 0d);//tf for lazy in docid1
+	
+		
+		DVFeaturedScoringMatching fsm = new DVFeaturedScoringMatching(index, null, 
+				new String[]{
+				"WMODELt:Tf",
+				"WMODEL$second:Tf"
+				}
+		);
+		ResultSet r2 = fsm.doMatch("test", mqt, frInput);
+		
+		//the order of the resultset from fsm is based on the original scores.
+		
+		TIntIntHashMap id2rank = new TIntIntHashMap();
+		for(int i=0;i<r2.getDocids().length;i++)
+		{
+			id2rank.put(r2.getDocids()[i], i);	
+		}
+		assertTrue(id2rank.contains(0));
+		assertTrue(id2rank.contains(1));
+		
+		assertEquals(2, r2.getResultSize());
+		assertEquals(frInput.getScores()[id2rank.get(0)], r2.getScores()[id2rank.get(0)], 0.0d);
+		assertEquals(frInput.getScores()[id2rank.get(1)], r2.getScores()[id2rank.get(1)], 0.0d);
+		
+		FeaturedResultSet featRes = (FeaturedResultSet)r2;
+		// org.terrier.structures.outputformat.LETOROutputFormat of = new org.terrier.structures.outputformat.LETOROutputFormat(index);
+		// org.terrier.querying.Request rq = new org.terrier.querying.Request();
+		// rq.setIndex(index);
+		// rq.setResultSet(featRes);
+		// of.printResults(new java.io.PrintWriter(System.out), rq, "ltr", "Q0", 100);
+		
+		final double[] tfs = featRes.getFeatureScores("WMODELt:Tf");
+		assertEquals(2, tfs.length);
+		assertEquals(3, tfs[id2rank.get(0)], 0.0d); //tf for lazy and fox in docid0
+		assertEquals(4, tfs[id2rank.get(1)], 0.0d); //tf for lazy and fox in docid1
+		
+		final double[] tfs2 = featRes.getFeatureScores("WMODEL$second:Tf");
+		assertEquals(2, tfs2.length);
+		assertEquals(1, tfs2[id2rank.get(0)], 0.0d);//tf for fox in docid0
+		assertEquals(3, tfs2[id2rank.get(1)], 0.0d);//tf for fox in docid1
+	}
+	
+	@Test 
+	public void singleDocumentMultipleTermsWithProx() throws Exception
+	{
+		ApplicationSetup.setProperty("termpipelines", "");
+		ApplicationSetup.setProperty("ignore.low.idf.terms", "false");
+		ApplicationSetup.setProperty("proximity.dependency.type","SD");
+		Index index = IndexTestUtils.makeIndexBlocks(
+				new String[]{"doc1"}, 
+				new String[]{"the lazy dog jumped over the quick fox"});
+		MatchingQueryTerms mqt = new MatchingQueryTerms();
+		mqt.setQueryId("test2");
+		mqt.setTermProperty("lazy", 1.0d);
+		mqt.setTermProperty("fox", 1.0d);		
+		mqt.add(QTPBuilder
+				.of(new PhraseOp(new String[]{"lazy", "dog"}))
+				.setWeight(0.1).setTag("sdm")
+				.setWeightingModels(Arrays.asList(new Tf()))
+				.build());
+		mqt.add(QTPBuilder
+				.of(new UnorderedWindowOp(new String[]{"lazy", "dog"}, 8))
+				.setWeight(0.1).setTag("sdm")
+				.setWeightingModels(Arrays.asList(new Tf()))
+				.build());
+		mqt.setDefaultTermWeightingModel(new Tf());
+		Matching m = new Full(index);
+		
+		ResultSet frInput = m.match("query1", mqt);
+			
+		
+		assertEquals(1, frInput.getResultSize());
+		assertEquals(0, frInput.getDocids()[0]);
+		assertTrue(frInput.getScores()[0] > 0);
+	
+		
+		DVFeaturedScoringMatching ffsm = new DVFeaturedScoringMatching(index, null, 
+				new String[]{
+				"WMODELt:Tf", 
+				"WMODELp:org.terrier.matching.models.dependence.pBiL", 
+				"DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier%proximity.ngram.length=2 proximity.plm.split.synonyms=false",
+				"DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier%proximity.ngram.length=8 proximity.plm.split.synonyms=false",
+				"WMODEL$sdm:org.terrier.matching.models.dependence.pBiL"}
+		);
+		ResultSet r2 = ffsm.doMatch("test", mqt, frInput);
+		
+		assertEquals(1, r2.getResultSize());
+		assertEquals(0, r2.getDocids()[0]);
+		assertEquals(frInput.getScores()[0], r2.getScores()[0], 0.0d);
+		
+		FeaturedResultSet featRes = (FeaturedResultSet)r2;
+		final double[] tfs = featRes.getFeatureScores("WMODELt:Tf");
+		assertEquals(1, tfs.length);
+		assertEquals(2, tfs[0], 0.0d);
+		
+		final double[] dls = featRes.getFeatureScores("WMODELp:org.terrier.matching.models.dependence.pBiL");
+		assertEquals(1, dls.length);
+		assertTrue(dls[0] > 0);
+		
+		final double[] proxSmall = featRes.getFeatureScores("DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier%proximity.ngram.length=2 proximity.plm.split.synonyms=false");
+		assertNotNull(proxSmall);
+		assertTrue(proxSmall[0] == 0);
+		
+		final double[] proxLarge = featRes.getFeatureScores("DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier%proximity.ngram.length=8 proximity.plm.split.synonyms=false");
+		assertNotNull(proxLarge);
+		assertTrue(proxLarge[0] > 0);
+		
+		final double[] proxNew = featRes.getFeatureScores("WMODEL$sdm:org.terrier.matching.models.dependence.pBiL");
+		assertNotNull(proxNew);
+		assertTrue(proxNew[0] > 0);
+			
+	}
+	
+}

--- a/modules/docvectors/src/test/java/org/terrier/matching/TestDVFeaturedScoringMatching2.java
+++ b/modules/docvectors/src/test/java/org/terrier/matching/TestDVFeaturedScoringMatching2.java
@@ -1,0 +1,169 @@
+/*
+ * Terrier - Terabyte Retriever 
+ * Webpage: http://terrier.org 
+ * Contact: terrier{a.}dcs.gla.ac.uk
+ * University of Glasgow - School of Computing Science
+ * http://www.gla.ac.uk/
+ * 
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+ * the License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * The Original Code is TestFatFeaturedScoringMatching.java.
+ *
+ * The Original Code is Copyright (C) 2004-2018 the University of Glasgow.
+ * All Rights Reserved.
+ *
+ * Contributor(s):
+ *   Craig Macdonald <craig.macdonald@glasgow.ac.uk>
+ */
+
+package org.terrier.matching;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import gnu.trove.TIntIntHashMap;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.terrier.indexing.IndexTestUtils;
+import org.terrier.learning.FeaturedResultSet;
+import org.terrier.matching.daat.Full;
+import org.terrier.matching.matchops.PhraseOp;
+import org.terrier.matching.matchops.UnorderedWindowOp;
+import org.terrier.matching.models.BM25;
+import org.terrier.matching.models.TF_IDF;
+import org.terrier.matching.models.Tf;
+import org.terrier.querying.DependenceModelPreProcess;
+import org.terrier.querying.MQTRewritingProcess;
+import org.terrier.querying.QueryExpansion;
+import org.terrier.querying.parser.Query.QTPBuilder;
+import org.terrier.structures.Index;
+import org.terrier.structures.IndexOnDisk;
+import org.terrier.tests.ApplicationSetupBasedTest;
+import org.terrier.utility.ApplicationSetup;
+
+public class TestDVFeaturedScoringMatching2 extends ApplicationSetupBasedTest {
+	
+	
+	@Test 
+	public void singleDocumentSingleTerm() throws Exception
+	{
+		ApplicationSetup.setProperty("termpipelines", "");
+		ApplicationSetup.setProperty("ignore.low.idf.terms", "false");
+		ApplicationSetup.setProperty("proximity.dependency.type","SD");
+		Index index = IndexTestUtils.makeIndex(
+				new String[]{"doc1"}, 
+				new String[]{"term"});
+		MatchingQueryTerms mqt = new MatchingQueryTerms();
+		mqt.setTermProperty("term", 1.0d);
+		mqt.setDefaultTermWeightingModel(new TF_IDF());
+		Matching m = new Full(index);
+		
+		ResultSet frInput = m.match("singleDocumentSingleTerm-Q1", mqt);
+		assertEquals(1, frInput.getResultSize());
+		assertEquals(0, frInput.getDocids()[0]);
+		assertTrue(frInput.getScores()[0] > 0);
+			
+		DVFeaturedScoringMatching ffsm = new DVFeaturedScoringMatching(index, null, 
+				new String[]{"WMODEL:Tf", "WMODEL:Dl", "DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier"}
+		);
+		ResultSet r2 = ffsm.doMatch("singleDocumentSingleTerm-Q2", mqt, frInput);
+		
+		assertEquals(1, r2.getResultSize());
+		assertEquals(0, r2.getDocids()[0]);
+		assertEquals(frInput.getScores()[0], r2.getScores()[0], 0.0d);
+		
+		FeaturedResultSet featRes = (FeaturedResultSet)r2;
+		final double[] tfs = featRes.getFeatureScores("WMODEL:Tf");
+		assertEquals(1, tfs.length);
+		assertEquals(1, tfs[0], 0.0d);
+		
+		final double[] dls = featRes.getFeatureScores("WMODEL:Dl");
+		assertEquals(1, dls.length);
+		assertEquals(1, dls[0], 0.0d);
+		
+		final double[] prox = featRes.getFeatureScores("DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier");
+		assertNotNull(prox);
+		//single term query can have no proximity, however, feature MUST be defined
+		assertEquals(0.0d, prox[0], 0.0d);
+	}
+	
+	
+	@Test 
+	public void singleDocumentMultipleTermsWithProx() throws Exception
+	{
+		ApplicationSetup.setProperty("termpipelines", "");
+		ApplicationSetup.setProperty("ignore.low.idf.terms", "false");
+		ApplicationSetup.setProperty("proximity.dependency.type","SD");
+		Index index = IndexTestUtils.makeIndexBlocks(
+				new String[]{"doc1"}, 
+				new String[]{"the lazy dog jumped over the quick fox"});
+		MatchingQueryTerms mqt = new MatchingQueryTerms();
+		mqt.setQueryId("test2");
+		mqt.setTermProperty("lazy", 1.0d);
+		mqt.setTermProperty("fox", 1.0d);		
+		mqt.add(QTPBuilder
+				.of(new PhraseOp(new String[]{"lazy", "dog"}))
+				.setWeight(0.1)
+				.setWeightingModels(Arrays.asList(new Tf()))
+				.build());
+		mqt.add(QTPBuilder
+				.of(new UnorderedWindowOp(new String[]{"lazy", "dog"}, 8))
+				.setWeight(0.1)
+				.setWeightingModels(Arrays.asList(new Tf()))
+				.build());
+		mqt.setDefaultTermWeightingModel(new Tf());
+		Matching m = new Full(index);
+		
+		ResultSet frInput = m.match("query1", mqt);
+			
+		
+		assertEquals(1, frInput.getResultSize());
+		assertEquals(0, frInput.getDocids()[0]);
+		assertTrue(frInput.getScores()[0] > 0);
+	
+		
+		DVFeaturedScoringMatching ffsm = new DVFeaturedScoringMatching(index, null, 
+				new String[]{
+				"WMODELt:Tf", 
+				"WMODELp:org.terrier.matching.models.dependence.pBiL", 
+				"DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier%proximity.ngram.length=2 proximity.plm.split.synonyms=false",
+				"DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier%proximity.ngram.length=8 proximity.plm.split.synonyms=false"}
+		);
+		ResultSet r2 = ffsm.doMatch("test", mqt, frInput);
+		
+		assertEquals(1, r2.getResultSize());
+		assertEquals(0, r2.getDocids()[0]);
+		assertEquals(frInput.getScores()[0], r2.getScores()[0], 0.0d);
+		
+		FeaturedResultSet featRes = (FeaturedResultSet)r2;
+		final double[] tfs = featRes.getFeatureScores("WMODELt:Tf");
+		assertEquals(1, tfs.length);
+		assertEquals(2, tfs[0], 0.0d);
+		
+		final double[] dls = featRes.getFeatureScores("WMODELp:org.terrier.matching.models.dependence.pBiL");
+		assertEquals(1, dls.length);
+		assertTrue(dls[0] > 0);
+		
+		final double[] proxSmall = featRes.getFeatureScores("DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier%proximity.ngram.length=2 proximity.plm.split.synonyms=false");
+		assertNotNull(proxSmall);
+		assertTrue(proxSmall[0] == 0);
+		
+		final double[] proxLarge = featRes.getFeatureScores("DSM:org.terrier.matching.dsms.DFRDependenceScoreModifier%proximity.ngram.length=8 proximity.plm.split.synonyms=false");
+		assertNotNull(proxLarge);
+		assertTrue(proxLarge[0] > 0);
+	
+			
+	}
+	
+}

--- a/modules/index-api/pom.xml
+++ b/modules/index-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/learning/pom.xml
+++ b/modules/learning/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/learning/src/main/java/org/terrier/matching/FeaturedScoringMatching.java
+++ b/modules/learning/src/main/java/org/terrier/matching/FeaturedScoringMatching.java
@@ -25,7 +25,7 @@ import org.terrier.utility.Files;
 
 public abstract class FeaturedScoringMatching extends FilterMatching {
 	
-	protected static Logger logger = LoggerFactory.getLogger(FatFeaturedScoringMatching.class);
+	protected static Logger logger = LoggerFactory.getLogger(FeaturedScoringMatching.class);
 	protected Index index;
 	protected AbstractScoringMatching[] wModels;
 	protected String[] wModelNames;
@@ -184,7 +184,6 @@ public abstract class FeaturedScoringMatching extends FilterMatching {
 				AbstractScoringMatching fsm = scoringMatchingImpl
 						.getConstructor(Index.class, Matching.class, WeightingModel.class, Predicate.class)
 						.newInstance(null, parent, wm, filter);
-				//		new FatScoringMatching(null, parent, wm, filter);
 				fsm.sort = false;
 				_childrenWmodels.add(fsm);
 				_childrenWmodelNames.add(featureNames[i]);

--- a/modules/learning/src/main/java/org/terrier/matching/ScoringMatching.java
+++ b/modules/learning/src/main/java/org/terrier/matching/ScoringMatching.java
@@ -174,12 +174,14 @@ public class ScoringMatching extends AbstractScoringMatching {
 		if (numScored == getFinalResultSet().getResultSize())
 		{
 			rs_input = getFinalResultSet();
-			rs_input.sort();
+			if (sort)
+				rs_input.sort();
 		}
 		else
 		{
 			rs_input = getFinalResultSet();
-			rs_input.sort(numScored);
+			if (sort)
+				rs_input.sort(numScored);
 			rs_input = rs_input.getResultSet(0, numScored);
 		}
 	}

--- a/modules/logging/pom.xml
+++ b/modules/logging/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/realtime/pom.xml
+++ b/modules/realtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/rest-client/pom.xml
+++ b/modules/rest-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/rest-server/pom.xml
+++ b/modules/rest-server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/retrieval-api/pom.xml
+++ b/modules/retrieval-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/modules/tests/pom.xml
+++ b/modules/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>terrier-platform</artifactId>
 		<groupId>org.terrier</groupId>
-		<version>5.9</version>
+		<version>5.10-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.terrier</groupId>
 	<artifactId>terrier-platform</artifactId>
-	<version>5.9</version>
+	<version>5.10-SNAPSHOT</version>
 	<name>Terrier Information Retrieval Platform</name>
 	<description>Terrier IR platform</description>
 	<url>http://terrier.org</url>
@@ -73,6 +73,7 @@
 		<module>modules/concurrent</module>
 		<module>modules/realtime</module>
 		<module>modules/rest-server</module>
+		<module>modules/docvectors</module>
 		<module>modules/assemblies</module>
 	</modules>
 


### PR DESCRIPTION
Docvectors is an alternative formulation to the Fat framework. The aim is to expose this using the PyTerrier FeaturesRetrieve class.