### PR TITLE
Bump logback and slf4j versions

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 
 		<dependency>

--- a/modules/index-api/pom.xml
+++ b/modules/index-api/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-client -->

--- a/modules/logging/pom.xml
+++ b/modules/logging/pom.xml
@@ -14,13 +14,13 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.13</version>
+			<version>${logback.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
-			<version>1.2.13</version>
+			<version>${logback.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/modules/rest-client/pom.xml
+++ b/modules/rest-client/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 
 		<dependency>

--- a/modules/rest-server/pom.xml
+++ b/modules/rest-server/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.13</version>
+			<version>${logback.version}</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/modules/tests/pom.xml
+++ b/modules/tests/pom.xml
@@ -57,14 +57,14 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.13</version>
+			<version>${logback.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
-			<version>1.2.13</version>
+			<version>${logback.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<timestamp>${maven.build.timestamp}</timestamp>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<organization>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<timestamp>${maven.build.timestamp}</timestamp>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-		<logback.version>1.2.13</logback.version>
+		<logback.version>1.4.14</logback.version>
+		<slf4j.version>2.0.16</slf4j.version>
 	</properties>
 
 	<organization>


### PR DESCRIPTION
Importing Anserini 0.35.1 (which includes Spring) and a more modern logback version into PyTerrier causes logback errors. As a result, we need to upgrade our loggers. This appears to work