### PR TITLE
Bump most JDK version tested in GHA to 21

### DIFF
--- a/.github/workflows/build-unit-tests.yml
+++ b/.github/workflows/build-unit-tests.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 13]
+        java: [11, 21]
         os: ['ubuntu-latest', 'macOs-latest', 'windows-latest']
         architecture: ['x64']
 


### PR DESCRIPTION
We should check Terrier works on something more recent that JDK 13