### PR TITLE
Indexer returns ref

### DIFF
--- a/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
+++ b/modules/batch-indexers/src/main/java/org/terrier/structures/indexing/Indexer.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.terrier.indexing.Collection;
 import org.terrier.indexing.CollectionFactory;
 import org.terrier.indexing.Document;
+import org.terrier.querying.IndexRef;
 import org.terrier.structures.AbstractPostingOutputStream;
 import org.terrier.structures.BasicDocumentIndexEntry;
 import org.terrier.structures.DocumentIndexEntry;
@@ -351,8 +352,8 @@ public abstract class Indexer
 			logger.info("Watching for "+BUILDER_BOUNDARY_DOCUMENTS.size()+ " documents that force index builder boundaries.");
 	}
 
-	public void index(Collection[] collections) {
-		index(CollectionFactory.compose(collections));
+	public IndexRef index(Collection[] collections) {
+		return index(CollectionFactory.compose(collections));
 	}
 	
 	/**
@@ -363,7 +364,7 @@ public abstract class Indexer
 	 * the generated data structures.
 	 * @param collection The document collection object to index.
 	 */
-	public void index(Collection collection) {
+	public IndexRef index(Collection collection) {
 		int counter = 0;
 		final String oldIndexPrefix = prefix;
 		
@@ -393,6 +394,7 @@ public abstract class Indexer
 		//restore the prefix
 		prefix = oldIndexPrefix;
 		fileNameNoExtension = path + ApplicationSetup.FILE_SEPARATOR + prefix;
+		return IndexRef.of(path, prefix);
 	}
 
 	/** Indexes document as provided by the specified iterator.

--- a/modules/realtime/src/main/java/org/terrier/realtime/memory/MemoryIndexer.java
+++ b/modules/realtime/src/main/java/org/terrier/realtime/memory/MemoryIndexer.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import org.terrier.indexing.Collection;
 import org.terrier.indexing.Document;
 import org.terrier.realtime.memory.fields.MemoryFieldsIndex;
+import org.terrier.querying.IndexRef;
 import org.terrier.structures.Index;
 import org.terrier.structures.indexing.DocumentPostingList;
 import org.terrier.structures.indexing.FieldDocumentPostingList;
@@ -138,9 +139,10 @@ public class MemoryIndexer extends Indexer {
 	}
     
 	@Override
-    public void index(Collection collection) {
+    public IndexRef index(Collection collection) {
         this.createDirectIndex(collection);
 		this.createInvertedIndex();
+		return this.memIndex.getIndexRef();
     }
 	
 	public void createDirectIndex(Collection collection) {

--- a/modules/tests/src/main/java/org/terrier/indexing/IndexTestUtils.java
+++ b/modules/tests/src/main/java/org/terrier/indexing/IndexTestUtils.java
@@ -36,7 +36,9 @@ import java.util.Map;
 
 import org.terrier.indexing.tokenisation.EnglishTokeniser;
 import org.terrier.indexing.tokenisation.Tokeniser;
+import org.terrier.querying.IndexRef;
 import org.terrier.structures.Index;
+import org.terrier.structures.IndexFactory;
 import org.terrier.structures.IndexOnDisk;
 import org.terrier.structures.indexing.Indexer;
 import org.terrier.structures.indexing.classical.BasicIndexer;
@@ -122,8 +124,9 @@ public class IndexTestUtils {
 			sourceDocs[i] = makeDocumentFromText(documents[i], docProperties);
 		}
 		Collection col = makeCollection(docnos, documents);
-		indexer.index(new Collection[]{col});		
-		Index index = Index.createIndex(path, prefix);
+		IndexRef ref = indexer.index(new Collection[]{col});
+		assertNotNull(ref);
+		Index index = IndexFactory.of(ref);
 		assertNotNull(index);
 		assertEquals(sourceDocs.length, index.getCollectionStatistics().getNumberOfDocuments());
 		return index;
@@ -143,8 +146,9 @@ public class IndexTestUtils {
 			sourceDocs[i] = new TaggedDocument(new ByteArrayInputStream(documents[i].getBytes()), docProperties, new EnglishTokeniser());
 		}
 		Collection col = new CollectionDocumentList(sourceDocs);
-		indexer.index(new Collection[]{col});		
-		Index index = Index.createIndex(path, prefix);
+		IndexRef ref = indexer.index(new Collection[]{col});
+		assertNotNull(ref);
+		Index index = IndexFactory.of(ref);
 		assertNotNull(index);
 		assertEquals(sourceDocs.length, index.getCollectionStatistics().getNumberOfDocuments());
 		return index;


### PR DESCRIPTION
PyTerrier code needs to construct an indexref once indexing finishes (See for instance https://github.com/terrier-org/pyterrier/blob/master/pyterrier/terrier/index.py#L694). This seems error prone - it makes sense that the Indexer returns the IndexRef for the index index (but the index isnt loaded, except for MemoryIndex).

This PR has the index() method return an IndexRef, and uses it in some tests

